### PR TITLE
Adds a script and schema file for property group design and graph export

### DIFF
--- a/src/assets/sddui-shacl-groups.yaml
+++ b/src/assets/sddui-shacl-groups.yaml
@@ -1,0 +1,33 @@
+property_groups:
+  - id: dlsddui:BasicPropertyGroup 
+    label: Basic
+    order: 0
+    description: >-
+      Basic properties of the dataset distribution
+  - id: dlsddui:DataPropertyGroup
+    label: Data
+    order: 1
+    description: >-
+      Properties related to the actual data file(s) of the dataset distribution
+  - id: dlsddui:PartsPropertyGroup
+    label: Parts
+    order: 2
+    description: >-
+      The parts that together constitute the whole of the dataset distribution
+  - id: dlsddui:ProvenancePropertyGroup
+    label: Provenance
+    order: 3
+    description: >-
+      Properties that define the Agents, Entities, Activities, and Roles
+      that together determined how a specific state of the dataset
+      distribution came to be
+  - id: dlsddui:RelationPropertyGroup
+    label: Relation
+    order: 4
+    description: >-
+      Properties that relate to the dataset distribution in any way or form
+  - id: dlsddui:AccessPropertyGroup
+    label: Access
+    order: 5
+    description: >-
+      Properties that describe how the dataset distribution can be accessed

--- a/tools/gen_shacl_ui.py
+++ b/tools/gen_shacl_ui.py
@@ -1,0 +1,98 @@
+"""
+gen_shacl_ui.py
+
+Generate a serialized graph of triples from a LinkML-turned-SHACL schema
+and a separately specified list of property groups.
+
+This script takes a LinkML schema with UI annotations and a data file
+containing a list property groups as input arguments and then:
+- validates the data file according to the LinkML schema located in this 
+  repository at 'tools/property_group_schema.yaml'
+- validates the UI-annotated schema (TODO)
+- converts the property groups in the data file to RDF
+- exports the UI-annotated schema to SHACL
+- combines the property groups and schema exports into a single graph
+- serializes the complete graph to a 'ttl' file
+
+This allows a user to design the categorical structure of a user interface
+via an easy-to-edit YAML file, and end up with a single-file graph that can
+be used as input to the 'shacl-vue' user interface.
+
+"""
+
+from argparse import ArgumentParser
+from linkml.validator import validate_file
+from pathlib import Path
+from rdflib import Graph, term
+import subprocess
+import sys
+
+def get_shacl(schema_path):
+    """"""
+    args = ['gen-shacl', '--include-annotations', str(schema_path)]
+    return run_subprocess(args)
+
+def get_groups_rdf(data_path, schema_path):
+    """"""
+    args = ['linkml-convert', '-s', str(schema_path), '-t', 'rdf', str(data_path)]
+    return run_subprocess(args)
+
+def run_subprocess(args):
+    return subprocess.run(args, capture_output=True, text=True).stdout
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--schema",
+        type=str,
+        help="Path to the LinkML schema with UI annotations (YAML)",
+    )
+    parser.add_argument(
+        "--property-groups",
+        type=str,
+        help="Path to the YAML data file containing 'PropertyGroup's",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="Path to the output 'ttl' file containing all triples",
+    )
+    args = parser.parse_args()
+
+    # 0. Establish some paths
+    fp = Path(__file__)
+    tools_dir = fp.parent.resolve()
+    prop_group_schema_file = tools_dir / 'property_group_schema.yaml'
+    prop_group_data_file = Path(args.property_groups).resolve()
+    curdir = Path.cwd()
+    if args.output:
+        output_path = Path(args.output).resolve()
+    else:
+        output_path = curdir / 'graph.ttl'
+    
+    # 1. First validate group data and schema
+    report = validate_file(prop_group_data_file, prop_group_schema_file)
+    if not report.results:
+        print('Property group data: valid!')
+    else:
+        for result in report.results:
+            print(result.message)
+        sys.exit()
+    # TODO: also validate the annotated schema!
+
+    # 2. Convert property group data file to RDF
+    groups_rdf = get_groups_rdf(prop_group_data_file, prop_group_schema_file)
+    
+    # 3. Generate SHACL from the annotated schema
+    schema_path = Path(args.schema).resolve()
+    shacl = get_shacl(schema_path)
+    
+    # 4. Combine all triples into the same graph, remove unnecessary triples, and serialize
+    g = Graph()
+    g.parse(data=groups_rdf)
+    g.parse(data=shacl)
+    g.remove((None, None, term.URIRef('https://concepts.datalad.org/s/pgui/unreleased/Container')))
+    g.remove((None, term.URIRef('https://concepts.datalad.org/s/pgui/unreleased/property_groups'), None))
+    g.serialize(destination=output_path)
+    print(f"Graph written to: {str(output_path)}")

--- a/tools/gen_shacl_ui.py
+++ b/tools/gen_shacl_ui.py
@@ -1,5 +1,7 @@
 """
+---------------
 gen_shacl_ui.py
+---------------
 
 Generate a serialized graph of triples from a LinkML-turned-SHACL schema
 and a separately specified list of property groups.
@@ -20,59 +22,34 @@ be used as input to the 'shacl-vue' user interface.
 
 """
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from linkml.validator import validate_file
 from pathlib import Path
 from rdflib import Graph, term
 import subprocess
 import sys
 
+
 def get_shacl(schema_path):
     """"""
     args = ['gen-shacl', '--include-annotations', str(schema_path)]
     return run_subprocess(args)
+
 
 def get_groups_rdf(data_path, schema_path):
     """"""
     args = ['linkml-convert', '-s', str(schema_path), '-t', 'rdf', str(data_path)]
     return run_subprocess(args)
 
+
 def run_subprocess(args):
     return subprocess.run(args, capture_output=True, text=True).stdout
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser()
-    parser.add_argument(
-        "--schema",
-        type=str,
-        help="Path to the LinkML schema with UI annotations (YAML)",
-    )
-    parser.add_argument(
-        "--property-groups",
-        type=str,
-        help="Path to the YAML data file containing 'PropertyGroup's",
-    )
-    parser.add_argument(
-        "--output",
-        type=str,
-        help="Path to the output 'ttl' file containing all triples",
-    )
-    args = parser.parse_args()
-
-    # 0. Establish some paths
-    fp = Path(__file__)
-    tools_dir = fp.parent.resolve()
-    prop_group_schema_file = tools_dir / 'property_group_schema.yaml'
-    prop_group_data_file = Path(args.property_groups).resolve()
-    curdir = Path.cwd()
-    if args.output:
-        output_path = Path(args.output).resolve()
-    else:
-        output_path = curdir / 'graph.ttl'
-    
-    # 1. First validate group data and schema
-    report = validate_file(prop_group_data_file, prop_group_schema_file)
+def validate_inputs(group_data_path, group_schema_path, schema_path):
+    """"""
+    # Validate data file
+    report = validate_file(group_data_path, group_schema_path)
     if not report.results:
         print('Property group data: valid!')
     else:
@@ -81,14 +58,13 @@ if __name__ == "__main__":
         sys.exit()
     # TODO: also validate the annotated schema!
 
-    # 2. Convert property group data file to RDF
-    groups_rdf = get_groups_rdf(prop_group_data_file, prop_group_schema_file)
-    
-    # 3. Generate SHACL from the annotated schema
-    schema_path = Path(args.schema).resolve()
+
+def combine_graphs(group_data_path, group_schema_path, schema_path):
+    # a. Convert property group data file to RDF
+    groups_rdf = get_groups_rdf(group_data_path, group_schema_path)
+    # b. Generate SHACL from the annotated schema
     shacl = get_shacl(schema_path)
-    
-    # 4. Combine all triples into the same graph, remove unnecessary triples, and serialize
+    # c. Combine all triples into the same graph, remove unnecessary triples, and serialize
     g = Graph()
     g.parse(data=groups_rdf)
     g.parse(data=shacl)
@@ -96,3 +72,51 @@ if __name__ == "__main__":
     g.remove((None, term.URIRef('https://concepts.datalad.org/s/pgui/unreleased/property_groups'), None))
     g.serialize(destination=output_path)
     print(f"Graph written to: {str(output_path)}")
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(epilog=__doc__,
+                            formatter_class=RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "schema",
+        type=str,
+        help="Path to the LinkML schema with UI annotations (YAML)",
+    )
+    parser.add_argument(
+        "property_groups",
+        type=str,
+        help="Path to the YAML data file containing 'PropertyGroup's",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        help="""Path to the output 'ttl' file containing all triples.
+              If not supplied, the output will be written to 'graph.ttl'
+              in the current working directory.""",
+    )
+    args = parser.parse_args()
+
+    # 0. Establish some paths
+    fp = Path(__file__)
+    tools_dir = fp.parent.resolve()
+    prop_group_schema_path = tools_dir / 'property_group_schema.yaml'
+    prop_group_data_path = Path(args.property_groups).resolve()
+    schema_path = Path(args.schema).resolve()
+    curdir = Path.cwd()
+    if args.output:
+        output_path = Path(args.output).resolve()
+    else:
+        output_path = curdir / 'graph.ttl'
+    
+    # 1. First validate group data and schema
+    validate_inputs(
+        group_data_path=prop_group_data_path,
+        group_schema_path=prop_group_schema_path,
+        schema_path=schema_path)
+    
+    # 2. Combine triples from data file and annotated schema
+    combine_graphs(
+        group_data_path=prop_group_data_path,
+        group_schema_path=prop_group_schema_path,
+        schema_path=schema_path)
+    

--- a/tools/property_group_schema.yaml
+++ b/tools/property_group_schema.yaml
@@ -1,0 +1,90 @@
+id: https://concepts.datalad.org/s/pgui/unreleased
+name: property_group_ui
+version: UNRELEASED
+status: bibo:status/draft
+title: Property Group schema for UI
+description: |
+  
+comments:
+  - ALL CONTENT HERE IS UNRELEASED AND MAY CHANGE ANY TIME
+
+license: MIT
+
+prefixes:
+  dlsddui: https://concepts.datalad.org/s/sddui/unreleased/
+  pgui: https://concepts.datalad.org/s/pgui/unreleased/
+  rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  sh: http://www.w3.org/ns/shacl#
+  xsd: http://www.w3.org/2001/XMLSchema#
+  linkml: https://w3id.org/linkml/
+
+emit_prefixes:
+  - pgui
+  - rdf
+  - rdfs
+  - sh
+  - xsd
+  - dlsddui
+
+imports:
+  - linkml:types
+
+slots:
+  id:
+    identifier: true
+    description: >-
+      The name of the property group that should be unique within the
+      context of a given graph.
+    range: string
+  label:
+    slot_uri: rdfs:label
+    description: >-
+      The label of the property group that will be displayed as the
+      heading of a section for this property group in the user interface
+    range: string
+  order:
+    slot_uri: sh:order
+    description: >-
+      The order that a 
+    range: decimal
+  description:
+    slot_uri: rdfs:comment
+    description: >-
+      A description of the 
+    range: string
+
+classes:
+  PropertyGroup:
+    class_uri: sh:PropertyGroup
+    description: >-
+      A property group will be used by nodes in a graph (i.e. fields) via
+      `sh:group` in order to group these nodes together under a relevant category.
+      All nodes that belong to a specific property group will be rendered together
+      in the resulting UI.
+    slots:
+      - id
+      - label
+      - order
+      - description
+    slot_usage:
+      id:
+        required: true
+      label:
+        required: true
+      order:
+        required: true
+      description:
+        required: true
+    see_also:
+      - https://www.w3.org/TR/shacl/#group
+      - https://datashapes.org/forms.html#property-groups
+  Container:
+    class_uri: pgui:Container
+    tree_root: true
+    attributes:
+      property_groups:
+        slot_uri: pgui:property_groups
+        multivalued: true
+        inlined_as_list: true
+        range: PropertyGroup


### PR DESCRIPTION
Closes https://github.com/psychoinformatics-de/shacl-vue/issues/14

We want to end up with a single file containing LinkML-exported shacl of a schema, including UI (and other) annotations, and a list of `sh:PropertyGroup`s that are used (also via annotations) to provide structure to the UI that will be autogenerated from the SHACL schema.

This PR/commit adds to files, a script and a schema for property groups. The script's docstring gives detailed insight:

> Generate a serialized graph of triples from a LinkML-turned-SHACL schema and a separately specified list of property groups.
> 
> This script takes a LinkML schema with UI annotations and a data file containing a list property groups as input arguments and then:
> - validates the data file according to the LinkML schema located in this repository at 'tools/property_group_schema.yaml'
> - validates the UI-annotated schema (TODO)
> - converts the property groups in the data file to RDF
> - exports the UI-annotated schema to SHACL
> - combines the property groups and schema exports into a single graph
> - serializes the complete graph to a 'ttl' file
> 
> This allows a user to design the categorical structure of a user interface via an easy-to-edit YAML file, and end up with a single-file graph that can be used as input to the 'shacl-vue' user interface.

The idea is that a user:
1. Authors their own LinkML schema with UI annotations
2. Authors their own list of property groups in YAML file (see example)
3. Runs the script:

```
python tools/gen_shacl_ui.py --schema ../datalad-concepts/src/sddui/unreleased.yaml --property-groups src/assets/sddui-shacl-groups.yaml
```