### PR TITLE
Many updates as part of initial development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+_ignore
 
 # local env files
 .env.local

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" href="/favicon.ico" />
+  <link rel="stylesheet" type="text/css" href="src/assets/style.css"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Welcome to shacl-vue!</title>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,18 +26,18 @@
       }
     },
     "node_modules/@antfu/utils": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.7.tgz",
-      "integrity": "sha512-gFPqTG7otEJ8uP6wrhDv6mqwGWYZKNvAcCq6u9hOj0c+IKCEsY4L1oC9trPq2SaWIzAfHvqfBDxF591JkMf+kg==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.8.tgz",
+      "integrity": "sha512-rWQkqXRESdjXtc+7NRfK9lASQjpXJu1ayp7qi1d23zZorY+wBHVLHHoVcMsEnkqEBWTFqbztO7/QdJFzyEcLTg==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.1.tgz",
-      "integrity": "sha512-Zo9c7N3xdOIQrNip7Lc9wvRPzlRtovHVE4lkz8WEDr7uYh/GMQhSiIgFxGIArRHYdJE5kxtZjAf8rT0xhdLCzg==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -489,13 +489,13 @@
       "integrity": "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg=="
     },
     "node_modules/@rdfjs/fetch-lite": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.2.tgz",
-      "integrity": "sha512-hcdg9gvMgaOLPGS1LAYPjyS3rjQg2x8G/do+ZTlHjIHrAtRzXZCa0ui+pzoT98258RQzxEGqajY4ug4IqSuHZw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.3.tgz",
+      "integrity": "sha512-CZfUsBekFIDYCoXBW59ehgYctIluqatWB0YqCJoA8scENuo5IHPXdPMiLt1YVqUnxQ4STwEBOUoIiaCVxwfOFg==",
       "dependencies": {
-        "is-stream": "^3.0.0",
+        "is-stream": "^4.0.1",
         "nodeify-fetch": "^3.1.0",
-        "readable-stream": "^4.4.2"
+        "readable-stream": "^4.5.2"
       }
     },
     "node_modules/@rdfjs/formats": {
@@ -719,9 +719,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
-      "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.0.tgz",
+      "integrity": "sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==",
       "cpu": [
         "arm"
       ],
@@ -731,9 +731,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
-      "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.0.tgz",
+      "integrity": "sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==",
       "cpu": [
         "arm64"
       ],
@@ -743,9 +743,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
-      "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.0.tgz",
+      "integrity": "sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==",
       "cpu": [
         "arm64"
       ],
@@ -755,9 +755,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
-      "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.0.tgz",
+      "integrity": "sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==",
       "cpu": [
         "x64"
       ],
@@ -767,9 +767,21 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
-      "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.0.tgz",
+      "integrity": "sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.0.tgz",
+      "integrity": "sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==",
       "cpu": [
         "arm"
       ],
@@ -779,9 +791,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
-      "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.0.tgz",
+      "integrity": "sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +803,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
-      "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.0.tgz",
+      "integrity": "sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==",
       "cpu": [
         "arm64"
       ],
@@ -802,10 +814,22 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.0.tgz",
+      "integrity": "sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
-      "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.0.tgz",
+      "integrity": "sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==",
       "cpu": [
         "riscv64"
       ],
@@ -814,10 +838,22 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.0.tgz",
+      "integrity": "sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
-      "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.0.tgz",
+      "integrity": "sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==",
       "cpu": [
         "x64"
       ],
@@ -827,9 +863,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
-      "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.0.tgz",
+      "integrity": "sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==",
       "cpu": [
         "x64"
       ],
@@ -839,9 +875,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
-      "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.0.tgz",
+      "integrity": "sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==",
       "cpu": [
         "arm64"
       ],
@@ -851,9 +887,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
-      "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.0.tgz",
+      "integrity": "sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==",
       "cpu": [
         "ia32"
       ],
@@ -863,9 +899,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
-      "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.0.tgz",
+      "integrity": "sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==",
       "cpu": [
         "x64"
       ],
@@ -900,9 +936,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -915,11 +951,6 @@
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
       }
-    },
-    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.0.4",
@@ -935,94 +966,94 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
-      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/shared": "3.4.27",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
-      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-core": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
-      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.21",
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.4",
+        "@vue/compiler-core": "3.4.27",
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.7",
-        "postcss": "^8.4.35",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
-      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
-      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+      "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
       "dependencies": {
-        "@vue/shared": "3.4.21"
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
-      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+      "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
       "dependencies": {
-        "@vue/reactivity": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/reactivity": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
-      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+      "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@vue/runtime-core": "3.4.27",
+        "@vue/shared": "3.4.27",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
-      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+      "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
-        "vue": "3.4.21"
+        "vue": "3.4.27"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
-      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g=="
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
     },
     "node_modules/@vuetify/loader-shared": {
       "version": "2.0.3",
@@ -1120,12 +1151,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "devOptional": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1354,9 +1385,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1459,9 +1490,9 @@
       ]
     },
     "node_modules/immutable": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
-      "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
+      "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
       "devOptional": true
     },
     "node_modules/is-binary-path": {
@@ -1519,11 +1550,11 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1559,9 +1590,9 @@
       }
     },
     "node_modules/jsonld-context-parser/node_modules/@types/node": {
-      "version": "18.19.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.26.tgz",
-      "integrity": "sha512-+wiMJsIwLOYCvUqSdKTrfkS8mpTp+MPINe6+Np4TAGFWWRWiBQ5kSq9nZGCSPkzx9mvT+uEukzpX4MOSCydcvw==",
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1664,14 +1695,11 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.8",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
-      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/merge2": {
@@ -1684,12 +1712,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -1716,9 +1744,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -1846,9 +1874,9 @@
       "dev": true
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -2046,9 +2074,9 @@
       "integrity": "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g=="
     },
     "node_modules/rollup": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
-      "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.0.tgz",
+      "integrity": "sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==",
       "devOptional": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -2061,19 +2089,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.13.0",
-        "@rollup/rollup-android-arm64": "4.13.0",
-        "@rollup/rollup-darwin-arm64": "4.13.0",
-        "@rollup/rollup-darwin-x64": "4.13.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.13.0",
-        "@rollup/rollup-linux-arm64-musl": "4.13.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
-        "@rollup/rollup-linux-x64-gnu": "4.13.0",
-        "@rollup/rollup-linux-x64-musl": "4.13.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.13.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.13.0",
-        "@rollup/rollup-win32-x64-msvc": "4.13.0",
+        "@rollup/rollup-android-arm-eabi": "4.18.0",
+        "@rollup/rollup-android-arm64": "4.18.0",
+        "@rollup/rollup-darwin-arm64": "4.18.0",
+        "@rollup/rollup-darwin-x64": "4.18.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.18.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.18.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.18.0",
+        "@rollup/rollup-linux-arm64-musl": "4.18.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.18.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.18.0",
+        "@rollup/rollup-linux-x64-gnu": "4.18.0",
+        "@rollup/rollup-linux-x64-musl": "4.18.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.18.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.18.0",
+        "@rollup/rollup-win32-x64-msvc": "4.18.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -2101,28 +2132,14 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/sass": {
-      "version": "1.72.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.72.0.tgz",
-      "integrity": "sha512-Gpczt3WA56Ly0Mn8Sl21Vj94s1axi9hDIzDFn9Ph9x3C3p4nNyvsqJoQyVXKou6cBlfFWEgRW4rT8Tb4i3XnVA==",
+      "version": "1.77.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.2.tgz",
+      "integrity": "sha512-eb4GZt1C3avsX3heBNlrc7I09nyT00IUuo4eFhAbeXWU2fvA7oXI53SxODVAA+zgZCk9aunAZgO+losjR3fAwA==",
       "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -2166,6 +2183,25 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -2196,9 +2232,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
+      "version": "5.28.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
+      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },
@@ -2212,9 +2248,9 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unplugin": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.10.0.tgz",
-      "integrity": "sha512-CuZtvvO8ua2Wl+9q2jEaqH6m3DoQ38N7pvBYQbbaeNlWGvK2l6GHiKi29aIHDPoSxdUzQ7Unevf1/ugil5X6Pg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.10.1.tgz",
+      "integrity": "sha512-d6Mhq8RJeGA8UfKCu54Um4lFA0eSaRa3XxdAJg8tIdxbu1ubW0hBCZUL7yI2uGyYCRndvbK8FLHzqy2XKfeMsg==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.3",
@@ -2298,13 +2334,13 @@
       "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA=="
     },
     "node_modules/vite": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.6.tgz",
-      "integrity": "sha512-FPtnxFlSIKYjZ2eosBQamz4CbyrTizbZ3hnGJlh/wMtCrlp1Hah6AzBLjGI5I2urTfNnpovpHdrL6YRuBOPnCA==",
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
+      "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
       "devOptional": true,
       "dependencies": {
         "esbuild": "^0.20.1",
-        "postcss": "^8.4.36",
+        "postcss": "^8.4.38",
         "rollup": "^4.13.0"
       },
       "bin": {
@@ -2372,15 +2408,15 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
-      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+      "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-sfc": "3.4.21",
-        "@vue/runtime-dom": "3.4.21",
-        "@vue/server-renderer": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-sfc": "3.4.27",
+        "@vue/runtime-dom": "3.4.27",
+        "@vue/server-renderer": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2392,9 +2428,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.11.tgz",
-      "integrity": "sha512-us5I0jyFwIQYG4v41PFmVMkoc/oJddVT4C2RFjJTI99ttigbQ92gsTeG5SB8BPfmfnUS4paR5BedZwk6W3KlJw==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.7.tgz",
+      "integrity": "sha512-oj7zrNbjKFlSS38449K9/ad9mc/o25bxuTFT9rs2AtSNnOA+BOLIVJCAPlmLGWoQGslPh80RzckXDedoifs+TQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },
@@ -2404,10 +2440,10 @@
       },
       "peerDependencies": {
         "typescript": ">=4.7",
-        "vite-plugin-vuetify": ">=2.0.3",
+        "vite-plugin-vuetify": ">=1.0.0",
         "vue": "^3.3.0",
         "vue-i18n": "^9.0.0",
-        "webpack-plugin-vuetify": ">=2.0.0-alpha.11"
+        "webpack-plugin-vuetify": ">=2.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@rdfjs/parser-n3": "^2.0.2",
         "rdf-ext": "^2.5.1",
         "roboto-fontface": "*",
+        "uuid": "^10.0.0",
         "vue": "^3.4.0",
         "vuetify": "^3.5.0"
       },
@@ -2326,6 +2327,18 @@
       "engines": {
         "node": ">=4",
         "yarn": "*"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-iri": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@rdfjs/parser-n3": "^2.0.2",
     "rdf-ext": "^2.5.1",
     "roboto-fontface": "*",
+    "uuid": "^10.0.0",
     "vue": "^3.4.0",
     "vuetify": "^3.5.0"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <v-app>
       <AppHeader />
       <v-main v-show="page_ready">
-        <v-container class="ml-1 mr-1">
+        <v-container fluid>
           <v-row align="start" no-gutters>
             <!-- <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col> -->
             <v-col>
@@ -14,36 +14,44 @@
             </v-col>
             <v-col cols="3"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
           </v-row>
-          <v-row align="start" style="height: 150px;" no-gutters>
+          <v-row align="start" style="height: 150px; flex-wrap: nowrap" no-gutters>
               <!-- <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col> -->
-              <v-col cols="8">
+              <v-col cols="6">
+                <h3>Selected Node</h3>
                   <v-sheet class="pa-4" border rounded elevation="2">
                       <span v-if="selectedIRI && prefixes_ready">
-                          <NodeShapeEditor :prefixes="prefixes" :shape_iri="selectedIRI" :shape_obj="selectedShape" :prop_groups="propertyGroups"/>
+                          <NodeShapeEditor :key="selectedIRI" :prefixes="prefixes" :shape_iri="selectedIRI" :shape_obj="selectedShape" :prop_groups="propertyGroups"/>
                       </span>
                   </v-sheet>
               </v-col>
-              <v-col class="ml-4">
-                <v-sheet class="pa-4" border rounded elevation="2">
+              <v-col class="ml-6">
+                <span v-if="selectedIRI && prefixes_ready">
                   <h3>Data</h3>
+                  <v-sheet class="pa-4" border rounded elevation="2">
+                    <code>
+                      <span v-for="(value, key, index) in prefixes">
+                        @prefix {{ key }}: &lt;{{ value }}&gt; .<br>
+                      </span>
+                      <br>
+                      <span v-for="(value, key, index) in graph">
+                        _b{{ index }} <br>
+                        &nbsp;&nbsp;&nbsp; a {{ toCURIE(key) }}
+                        <span v-for="(prop_val, prop_key , prop_idx) in value.properties">
+                          <span v-if="prop_val.object">
+                             ; <br>
+                            &nbsp;&nbsp;&nbsp; {{ toCURIE(prop_key) }} &quot;{{  prop_val.object }}&quot;
+                          </span>
+                        </span> .
 
-                  Number of triples:
-                  <br>
-                  {{ Object.keys(graph).length }}
-                  <br><br>
-                  Graph:
-                  <br>
-                  <span v-for="key in Object.keys(graph)">
-                    <strong>{{ key }}:</strong><br>
-                    subject: {{ graph[key].subject }} <br>
-                    predicate: {{ graph[key].predicate }} <br>
-                    object: {{ graph[key].object }} <br>
-                  </span>                  
-                  <v-btn @click="printGraphstuff()">
-                    Button
-                  </v-btn>
 
-                </v-sheet>
+
+                        <br><br>
+                      </span>
+                    </code>
+
+
+                  </v-sheet>
+                </span>
               </v-col>
           </v-row>
         </v-container>
@@ -55,7 +63,7 @@
 
 
 <script setup>
-  import { ref, onMounted, onBeforeMount, provide, getCurrentInstance} from 'vue'
+  import { ref, onMounted, onBeforeMount, provide, getCurrentInstance, computed} from 'vue'
   import rdf from 'rdf-ext';
   import ParserN3  from '@rdfjs/parser-n3';
   import { Readable } from 'readable-stream';
@@ -83,7 +91,7 @@
   var selectedShape = ref(null)
   var graphDataset = ref(rdf.dataset());
   var current_instance = ref(null)
-  const { graph, add_triple, remove_triple, edit_triple } = useGraph()
+  const { graph, add_triple, add_node, remove_triple, edit_triple } = useGraph()
 
 
   const defaultPropertyGroup = {}
@@ -97,6 +105,7 @@
   provide('defaultPropertyGroup', defaultPropertyGroup)
   provide('graph', graph)
   provide('add_triple', add_triple)
+  provide('add_node', add_node)
   provide('remove_triple', remove_triple)
   provide('edit_triple', edit_triple)
   
@@ -114,6 +123,31 @@
     console.log("CURRENT INSTANCE")
     current_instance = getCurrentInstance()
     console.log(current_instance)
+  })
+
+  // ------------------- //
+  // Computed properties //
+  // ------------------- //
+
+  const all_triples = computed(() => {
+
+    var triples = {}
+    for (const [idx, key] of Object.keys(graph).entries()) {
+      triples[key] = {
+        subject: graph[key].subject,
+        predicate: graph[key].predicate,
+        object: graph[key].object
+      }
+
+      for (const [jdx, tkey] of Object.keys(graph[key].properties).entries()) {
+        triples[tkey] = {
+          subject: graph[key].properties[tkey].subject,
+          predicate: graph[key].properties[tkey].predicate,
+          object: graph[key].properties[tkey].object
+        }
+      }
+    }
+    return triples
   })
 
   // --------- //
@@ -259,6 +293,7 @@
   function selectIRI(IRI) { 
       selectedIRI.value = IRI
       selectedShape.value = nodeShapes[IRI]
+      add_node(IRI)
   }
 
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,12 +2,9 @@
   <v-app>
       <AppHeader />
       <v-main v-show="page_ready">
-
-        
-
-        <v-container class=" mb-6">
+        <v-container class="ml-1 mr-1">
           <v-row align="start" no-gutters>
-            <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
+            <!-- <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col> -->
             <v-col>
               <v-select :items="nodeShapeNamesArray" item-title="name" label="Select a Node" density="compact">
                 <template v-slot:item="{ props, item }">
@@ -15,19 +12,23 @@
                 </template>
               </v-select>
             </v-col>
-            <v-col cols="2"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
+            <v-col cols="3"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
           </v-row>
           <v-row align="start" style="height: 150px;" no-gutters>
-              <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
-              <v-col>
+              <!-- <v-col cols="1"><v-sheet class="pa-2 ma-2"></v-sheet></v-col> -->
+              <v-col cols="8">
                   <v-sheet class="pa-4" border rounded elevation="2">
                       <span v-if="selectedIRI && prefixes_ready">
                           <NodeShapeEditor :prefixes="prefixes" :shape_iri="selectedIRI" :shape_obj="selectedShape" :prop_groups="propertyGroups"/>
                       </span>
-                      
                   </v-sheet>
               </v-col>
-              <v-col cols="2"><v-sheet class="pa-2 ma-2"></v-sheet></v-col>
+              <v-col class="ml-4">
+                <v-sheet class="pa-4" border rounded elevation="2">
+                  <h3>Data</h3>
+
+                </v-sheet>
+              </v-col>
           </v-row>
         </v-container>
           
@@ -42,13 +43,16 @@
   import rdf from 'rdf-ext';
   import ParserN3  from '@rdfjs/parser-n3';
   import { Readable } from 'readable-stream';
-  import {SHACL, RDF} from './plugins/namespaces'
+  import {SHACL, RDF} from './plugins/namespaces';
+  // import {SHACL, RDF} from './plugins/namespaces';  
   
+
   // ---- //
   // Data //
   // ---- //
 
-  const parserN3 = new ParserN3();
+  
+  const ttl_files = ["./assets/sddui-shacl.ttl", "./assets/sddui-shacl.ttl"]
   var shapesDataset = ref(null);
   var page_ready = ref(false);
   var prefixes_ready = ref(false);
@@ -61,6 +65,8 @@
   var prefixArray = ref(null);
   var selectedIRI = ref(null)
   var selectedShape = ref(null)
+  var graphDataset = ref(rdf.dataset());
+
 
   const defaultPropertyGroup = {}
   defaultPropertyGroup.key = "https://concepts.datalad.org/DefaultPropertyGroup"
@@ -84,9 +90,8 @@
   // --------- //
   // Functions //
   // --------- //
-
   function getSHACLschema() {
-      const shape_file_url = new URL("./assets/sddui-shacl.ttl", import.meta.url).href
+      const shape_file_url = new URL("./assets/graph.ttl", import.meta.url).href
       fetch(shape_file_url, {headers: {
           'Accept': 'text/turtle',
           'Content-Type': 'text/turtle',
@@ -94,6 +99,7 @@
       .then(response => response.text())
       .then(turtleContent => {
           const input = Readable.from(turtleContent)
+          const parserN3 = new ParserN3();
           const output = parserN3.import(input)
           nodeShapes = {}
           propertyGroups = {}

--- a/src/assets/graph.ttl
+++ b/src/assets/graph.ttl
@@ -1,0 +1,2081 @@
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix dlco: <https://concepts.datalad.org/> .
+@prefix dldist: <https://concepts.datalad.org/s/distribution/unreleased/> .
+@prefix dlprov: <https://concepts.datalad.org/s/prov/unreleased/> .
+@prefix dlsddui: <https://concepts.datalad.org/s/sddui/unreleased/> .
+@prefix dlthing: <https://concepts.datalad.org/s/thing/unreleased/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+dldist:Person a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Person agents are people." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:is_about ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 11 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:id ],
+        [ sh:class dldist:Organization ;
+            sh:description "An organization that an agent is affiliated with." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dldist:affiliation ],
+        [ sh:datatype dldist:EmailAddress ;
+            sh:description "Email address associated with an entity." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:email ;
+            sh:pattern "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])" ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 7 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:name ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "Physical address of the subject, such as a postal address, a bibliographic locator, or a coordinate of some kind." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:address ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:description ] ;
+    sh:targetClass dldist:Person .
+
+dlprov:Influence a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:description "Reference the resource (Entity, Agent, or Activity) whose influence is being qualified in a qualified influence pattern." ;
+            sh:maxCount 1 ;
+            sh:order 0 ;
+            sh:path dlprov:influencer ],
+        [ sh:class dlprov:Role ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:had_role ] ;
+    sh:targetClass dlprov:Influence .
+
+dlsddui:Grant a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A grant, typically financial or otherwise quantifiable, of resources." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path dlthing:same_as ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 5 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:Agent ;
+            sh:description "A person or organization that supports a thing through a pledge, promise, or financial contribution" ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlsddui:sponsor ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:is_about ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Entity that provides an authoritative description or definition of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlsddui:cites_as_authority ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 16 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:id ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 19 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 15 ;
+            sh:path dlthing:name ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path dlthing:title ] ;
+    sh:targetClass dlsddui:Grant .
+
+dlsddui:Publication a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A document that is the output of a publishing process. This can printed or electronic work offered for distribution, and may have been made available by a publisher." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 9 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:date_published ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 15 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 6 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 20 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 22 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 21 ;
+            sh:path dlthing:title ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 10 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dldist:LicenseDocument ;
+            sh:description "A legal document under which the resource is made available." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dldist:license ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 16 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:date_modified ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 19 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlthing:id ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 7 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:string ;
+            sh:description "Physical address of the subject, such as a postal address, a bibliographic locator, or a coordinate of some kind." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:address ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 11 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "String of characters such as \"T58:5\" or \"30:4833\" used to uniquely identify a concept within the scope of a given concept scheme." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:notation ] ;
+    sh:targetClass dlsddui:Publication .
+
+dlthing:Characteristic a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An inherent quality, function, disposition or process characteristic." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path rdfs:value ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the values of a property are instances of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path rdfs:range ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The property value is defined by this term." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:is_defined_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path rdf:type ] ;
+    sh:targetClass dlthing:Characteristic .
+
+dlthing:QuantitativeProperty a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An inherent quantitative property that is being observed or measured." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "State that the values of a property are instances of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path rdfs:range ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A unit of measurement is a standardized quantity of a physical quality." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:unit ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path rdfs:value ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The property value is defined by this term." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:is_defined_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:meta_type ] ;
+    sh:targetClass dlthing:QuantitativeProperty .
+
+dldist:Distribution a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A specific representation of data, which may come in the form of a single file, or an archive or directory of many files, may be standalone or part of a dataset." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 15 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 16 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:class dldist:Distribution ;
+            sh:description "A related resource that is included either physically or logically in the described resource." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dldist:has_part ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 21 ;
+            sh:path dlthing:id ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 31 ;
+            sh:path rdf:type ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 19 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dldist:QualifiedAccess ;
+            sh:description "Link to a description of a `access_service` relationship with `DCAT:DataService`." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlco:qualified_access ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 28 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 26 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 24 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:nonNegativeInteger ;
+            sh:description "The size of a distribution in bytes." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:byte_size ],
+        [ sh:class dldist:LicenseDocument ;
+            sh:description "A legal document under which the resource is made available." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 10 ;
+            sh:path dldist:license ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 30 ;
+            sh:path dlthing:title ],
+        [ sh:class dldist:DataService ;
+            sh:description "A data service that gives access to a distribution." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dldist:access_service ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 18 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:class dldist:Resource ;
+            sh:description "Inverse property of `DCAT:distribution`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 9 ;
+            sh:path dldist:is_distribution_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The file format of a distribution." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dldist:format ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 23 ;
+            sh:path dlthing:description ],
+        [ sh:class dldist:Checksum ;
+            sh:description "The checksum property provides a mechanism that can be used to verify that the contents of a file or package have not changed." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dldist:checksum ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "URL that gives direct access to the subject in the form of a downloadable file in a given format." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dldist:download_url ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dldist:date_published ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "The media type of a distribution as defined by IANA" ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dldist:media_type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 25 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 29 ;
+            sh:path dlthing:same_as ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 20 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dldist:date_modified ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 27 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "URL that gives access to the subject. This can be, e.g, a landing page, feed, SPARQL endpoint." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:access_url ],
+        [ sh:class dldist:DistributionPart ;
+            sh:description "Qualified a `hasPart` relationship with another entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dldist:qualified_part ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 22 ;
+            sh:path dlthing:conforms_to ] ;
+    sh:targetClass dldist:Distribution .
+
+dldist:Organization a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A social or legal instititution such as a company, a society, or a university." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path rdf:type ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 9 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:id ],
+        [ sh:datatype xsd:string ;
+            sh:description "Physical address of the subject, such as a postal address, a bibliographic locator, or a coordinate of some kind." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:address ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:name ] ;
+    sh:targetClass dldist:Organization .
+
+dlprov:AgentInfluence a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Capacity of an agent to have an effect on the character, development, or behavior of another Entity, Agent, or Activity" ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Agent ;
+            sh:description "References an agent which influenced an entity." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:agent ],
+        [ sh:description "Reference the resource (Entity, Agent, or Activity) whose influence is being qualified in a qualified influence pattern." ;
+            sh:maxCount 1 ;
+            sh:order 1 ;
+            sh:path dlprov:influencer ],
+        [ sh:class dlprov:Role ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprov:had_role ] ;
+    sh:targetClass dlprov:AgentInfluence .
+
+dlsddui:PartsPropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Parts" ;
+    rdfs:comment "The parts that together constitute the whole of the dataset distribution" ;
+    sh:order 2.0 .
+
+dlsddui:ScientificDataDistribution a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A dataset collected for the purpose of conducting scientific research. It may come in the form of a single file, or an archive or directory of many files. It may be standalone or part of another dataset." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:name "Is About" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dlthing:is_about ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:group dlsddui:ProvenancePropertyGroup ;
+            sh:name "Qualified Derivation" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:name "Identifier" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:group dlsddui:RelationPropertyGroup ;
+            sh:name "Has Property" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 0 ;
+            sh:path dlthing:has_property ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:group dlsddui:ProvenancePropertyGroup ;
+            sh:name "Qualified Attribution" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "URL that gives direct access to the subject in the form of a downloadable file in a given format." ;
+            sh:group dlsddui:AccessPropertyGroup ;
+            sh:name "Download URL" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:download_url ],
+        [ sh:class dldist:QualifiedAccess ;
+            sh:description "Link to a description of a `access_service` relationship with `DCAT:DataService`." ;
+            sh:group dlsddui:AccessPropertyGroup ;
+            sh:name "Qualified Access" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlco:qualified_access ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Date Published" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dldist:date_published ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:group dlsddui:ProvenancePropertyGroup ;
+            sh:name "Was Attributed To" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Meta type" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dldist:DataService ;
+            sh:description "A data service that gives access to a distribution." ;
+            sh:group dlsddui:AccessPropertyGroup ;
+            sh:name "Access Service" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dldist:access_service ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "URL that gives access to the subject. This can be, e.g, a landing page, feed, SPARQL endpoint." ;
+            sh:group dlsddui:AccessPropertyGroup ;
+            sh:name "Access URL" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:access_url ],
+        [ sh:class dldist:Checksum ;
+            sh:description "The checksum property provides a mechanism that can be used to verify that the contents of a file or package have not changed." ;
+            sh:group dlsddui:DataPropertyGroup ;
+            sh:name "Checksum" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dldist:checksum ],
+        [ sh:class dldist:LicenseDocument ;
+            sh:description "A legal document under which the resource is made available." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "License" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 10 ;
+            sh:path dldist:license ],
+        [ sh:datatype xsd:nonNegativeInteger ;
+            sh:description "The size of a distribution in bytes." ;
+            sh:group dlsddui:DataPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Byte Size" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:byte_size ],
+        [ sh:datatype xsd:string ;
+            sh:description "The media type of a distribution as defined by IANA" ;
+            sh:group dlsddui:DataPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Media Type" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:media_type ],
+        [ sh:class dldist:DistributionPart ;
+            sh:description "Qualified a `hasPart` relationship with another entity." ;
+            sh:group dlsddui:PartsPropertyGroup ;
+            sh:name "Qualified Part" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dldist:qualified_part ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:group dlsddui:RelationPropertyGroup ;
+            sh:name "Qualified Relation" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:name "Same As" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Name" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:name ],
+        [ sh:class dlsddui:ScientificDataDistribution ;
+            sh:description "A related resource that is included either physically or logically in the described resource." ;
+            sh:group dlsddui:PartsPropertyGroup ;
+            sh:name "range" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dldist:has_part ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Title" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:name "Conforms To" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The file format of a distribution." ;
+            sh:group dlsddui:DataPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Data Format" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:format ],
+        [ dash:singleLine false ;
+            sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Description" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:description ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:group dlsddui:ProvenancePropertyGroup ;
+            sh:name "Was Generated By" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:group dlsddui:RelationPropertyGroup ;
+            sh:name "Relation" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "ID" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:id ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Date Modified" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dldist:date_modified ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:group dlsddui:ProvenancePropertyGroup ;
+            sh:name "Was Derived From" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dldist:Resource ;
+            sh:description "Inverse property of `DCAT:distribution`." ;
+            sh:group dlsddui:BasicPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Is Distribution Of" ;
+            sh:nodeKind sh:IRI ;
+            sh:order 9 ;
+            sh:path dldist:is_distribution_of ] ;
+    sh:targetClass dlsddui:ScientificDataDistribution .
+
+dldist:Checksum a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A Checksum is a value that allows to check the integrity of the contents of a file. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Identifies the algorithm used to produce the subject `Checksum`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path spdx:algorithm ],
+        [ sh:datatype xsd:hexBinary ;
+            sh:description "Lower case hexadecimal encoded checksum digest value produced using a specific algorithm." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:digest ;
+            sh:pattern "^[a-fA-F0-9]+$" ] ;
+    sh:targetClass dldist:Checksum .
+
+dldist:DistributionPart a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An association class for attaching additional information to a hasPart relationship." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Entity ;
+            sh:description "References an entity which influenced an entity." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:entity ],
+        [ sh:datatype xsd:string ;
+            sh:description "The name of the part within the containing entity." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:name ] ;
+    sh:targetClass dldist:DistributionPart .
+
+dldist:Parameter a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A variable whose value changes the characteristics of a system or a function." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path rdfs:value ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the values of a property are instances of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path rdfs:range ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The property value is defined by this term." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:is_defined_by ] ;
+    sh:targetClass dldist:Parameter .
+
+dldist:QualifiedAccess a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An association class for attaching additional information to an `access_service` relationship between a `DCAT:Distribution` and a `DCAT:DataService`." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dldist:Parameter ;
+            sh:description "Relation between a process or function and an information entity which modulates the behaviour of the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dldist:has_parameter ],
+        [ sh:class dldist:DataService ;
+            sh:description "A data service that gives access to a distribution." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dldist:access_service ] ;
+    sh:targetClass dldist:QualifiedAccess .
+
+dlsddui:RelationPropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Relation" ;
+    rdfs:comment "Properties that relate to the dataset distribution in any way or form" ;
+    sh:order 4.0 .
+
+dldist:DataService a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A collection of operations that provides access to one or more distributions or data processing functions." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 21 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 25 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of a resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dldist:version ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Relevant contact information for the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dldist:contact_point ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 23 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 24 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the resource." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dldist:keyword ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 20 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 27 ;
+            sh:path dlthing:same_as ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 28 ;
+            sh:path dlthing:title ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 18 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:class dldist:Resource ;
+            sh:description "A related resource that is included either physically or logically in the described resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dldist:is_part_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A Web page that can be navigated to in a Web browser to gain access to a resource, its distributions and/or additional information." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dldist:landing_page ],
+        [ sh:datatype xsd:string ;
+            sh:description "A URL template with placeholders enclosed in braces (`{example}`). When expanded with a given set of named parameters, the instantiated template forms a valid URL suitable for requesting a download." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:download_url_template ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 26 ;
+            sh:path dlthing:has_property ],
+        [ sh:class dldist:Parameter ;
+            sh:description "Parameter that needs to be supplied in order to request a particular `Distribution` from the `DataService`. Any such concrete parameter values can be specific in a dedicated `QualifiedAccess` relation, linking a `Distribution` to a `DataService`. A `Parameter` value property given in the scope of a `DataService` can be considered as a default value." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dldist:has_parameter ],
+        [ sh:class dldist:Resource ;
+            sh:description "A related resource of which the described resource is a version." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dldist:is_version_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A description of the services available via the end-points, including their operations, parameters etc." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:endpoint_description ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 22 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 29 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 19 ;
+            sh:path dlthing:id ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dldist:date_published ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The root location or primary endpoint of a service (a Web-resolvable IRI)." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:endpoint_url ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dldist:date_modified ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ] ;
+    sh:targetClass dldist:DataService .
+
+dldist:LicenseDocument a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A legal document giving official permission to do something with a resource." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 5 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 16 ;
+            sh:path dlthing:same_as ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 11 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 15 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A copy of the actual text of a license reference, file or snippet that is associated with a License Identifier to aid in future analysis." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dldist:license_text ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:id ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path dlthing:name ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprov:was_generated_by ] ;
+    sh:targetClass dldist:LicenseDocument .
+
+dlsddui:AccessPropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Access" ;
+    rdfs:comment "Properties that describe how the dataset distribution can be accessed" ;
+    sh:order 5.0 .
+
+dlsddui:DataPropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Data" ;
+    rdfs:comment "Properties related to the actual data file(s) of the dataset distribution" ;
+    sh:order 1.0 .
+
+dlsddui:ProvenancePropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Provenance" ;
+    rdfs:comment "Properties that define the Agents, Entities, Activities, and Roles that together determined how a specific state of the dataset distribution came to be" ;
+    sh:order 3.0 .
+
+dlprov:Role a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A role is the function of a resource or agent with respect to another resource, in the context of resource attribution or resource relationships." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:id ] ;
+    sh:targetClass dlprov:Role .
+
+dldist:Resource a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Resource published or curated by a single agent." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of a resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dldist:version ],
+        [ sh:class dldist:Resource ;
+            sh:description "A related resource that is included either physically or logically in the described resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dldist:is_part_of ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 13 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dldist:date_published ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 16 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 15 ;
+            sh:path dlthing:id ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "Date on which the resource was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dldist:date_modified ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 14 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 8 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 18 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 21 ;
+            sh:path dlthing:name ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Relevant contact information for the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dldist:contact_point ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 25 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the resource." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dldist:keyword ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 12 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 20 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dldist:Resource ;
+            sh:description "A related resource of which the described resource is a version." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dldist:is_version_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 19 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 23 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A Web page that can be navigated to in a Web browser to gain access to a resource, its distributions and/or additional information." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dldist:landing_page ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 11 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 9 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 22 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 24 ;
+            sh:path dlthing:title ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 10 ;
+            sh:path dlprov:qualified_relation ] ;
+    sh:targetClass dldist:Resource .
+
+dlprov:Attribution a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Attribution is the ascribing of an entity to an agent." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Agent ;
+            sh:description "References an agent which influenced an entity." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:agent ],
+        [ sh:description "Reference the resource (Entity, Agent, or Activity) whose influence is being qualified in a qualified influence pattern." ;
+            sh:maxCount 1 ;
+            sh:order 1 ;
+            sh:path dlprov:influencer ],
+        [ sh:class dlprov:Role ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprov:had_role ] ;
+    sh:targetClass dlprov:Attribution .
+
+dlprov:Derivation a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlprov:had_activity ],
+        [ sh:class dlprov:Role ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dlprov:had_role ],
+        [ sh:class dlprov:Entity ;
+            sh:description "References an entity which influenced an entity." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:entity ],
+        [ sh:description "Reference the resource (Entity, Agent, or Activity) whose influence is being qualified in a qualified influence pattern." ;
+            sh:maxCount 1 ;
+            sh:order 3 ;
+            sh:path dlprov:influencer ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:meta_type ] ;
+    sh:targetClass dlprov:Derivation .
+
+dlprov:EntityInfluence a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Capacity of an entity to have an effect on the character, development, or behavior of another." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:description "Reference the resource (Entity, Agent, or Activity) whose influence is being qualified in a qualified influence pattern." ;
+            sh:maxCount 1 ;
+            sh:order 2 ;
+            sh:path dlprov:influencer ],
+        [ sh:class dlprov:Entity ;
+            sh:description "References an entity which influenced an entity." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:entity ],
+        [ sh:class dlprov:Role ;
+            sh:description "The function of an entity or agent with respect to another entity or resource." ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprov:had_role ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:meta_type ] ;
+    sh:targetClass dlprov:EntityInfluence .
+
+dlprov:Activity a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlprov:Agent ;
+            sh:description "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprov:was_associated_with ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprov:was_informed_by ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 15 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlthing:name ],
+        [ sh:datatype <https://www.w3.org/TR/NOTE-datetime> ;
+            sh:description "End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlprov:ended_at ;
+            sh:pattern "^(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 8 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlprov:AgentInfluence ;
+            sh:description "Assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 0 ;
+            sh:path dlprov:qualified_association ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlthing:id ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dlthing:description ] ;
+    sh:targetClass dlprov:Activity .
+
+dlprov:Entity a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlthing:is_about ],
+        [ sh:class dlprov:Attribution ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 0 ;
+            sh:path dlprov:qualified_attribution ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 16 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlthing:meta_type ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 10 ;
+            sh:path dlthing:identifier ],
+        [ sh:class dlprov:Derivation ;
+            sh:description "A transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlprov:qualified_derivation ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dlprov:was_attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 15 ;
+            sh:path dlthing:same_as ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprov:relation ],
+        [ sh:class dlprov:EntityInfluence ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject entity." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlprov:qualified_relation ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 5 ;
+            sh:path dlprov:was_derived_from ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlprov:was_generated_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dlthing:id ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:conforms_to ] ;
+    sh:targetClass dlprov:Entity .
+
+dlsddui:BasicPropertyGroup a sh:PropertyGroup ;
+    rdfs:label "Basic" ;
+    rdfs:comment "Basic properties of the dataset distribution" ;
+    sh:order 0.0 .
+
+dlthing:Identifier a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Identifier." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthing:Thing ;
+            sh:description "Name of the agency that issued an identifier." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlthing:schema_agency ],
+        [ sh:datatype xsd:string ;
+            sh:description "String of characters such as \"T58:5\" or \"30:4833\" used to uniquely identify a concept within the scope of a given concept scheme." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:notation ] ;
+    sh:targetClass dlthing:Identifier .
+
+dlthing:Property a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An inherent quality, function, disposition or process characteristic that is being observed or measured." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path rdfs:value ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the values of a property are instances of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path rdfs:range ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "The property value is defined by this term." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:is_defined_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:description ] ;
+    sh:targetClass dlthing:Property .
+
+dlthing:Thing a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "The most basic item." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlthing:id ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:description ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 7 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path rdf:type ],
+        [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthing:is_about ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlthing:meta_type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlthing:same_as ] ;
+    sh:targetClass dlthing:Thing .
+
+dlprov:Agent a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthing:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlthing:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of a thing. It is closely related to a name, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlthing:title ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "State that the subject is an instance of a class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Globally unique identifier of a metadata object." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthing:id ],
+        [ sh:class dlthing:Property ;
+            sh:description "Relation between a subject and a quality, capability or role that it bears." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 8 ;
+            sh:path dlthing:has_property ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path dlthing:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A relation of an information artifact to a thing. For example, the subject matter of the content." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlthing:is_about ],
+        [ sh:class dlthing:Thing ;
+            sh:description "The subject has a relation to the object." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlthing:conforms_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Property that determines that subject and object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subjects's identity. For example, the URL of the subjects's Wikipedia page, Wikidata entry, or official website." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlthing:same_as ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dlthing:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Type designator of a metadata object for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlthing:meta_type ] ;
+    sh:targetClass dlprov:Agent .
+

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,0 +1,3 @@
+code {
+    font-size: 12px;
+}

--- a/src/components/BooleanSelectEditor.vue
+++ b/src/components/BooleanSelectEditor.vue
@@ -1,14 +1,13 @@
 <template>
-    <v-switch label="No/Yes" v-bind="kaas" inset></v-switch>
-    <span>{{ kaas }}</span>
+    <v-switch label="No/Yes" v-model="graph[props.node_uid].properties[props.triple_uid].object" inset></v-switch>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
-    var kaas = ref('')
-
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-
+    const graph = inject('graph');
 </script>

--- a/src/components/BooleanSelectEditor.vue
+++ b/src/components/BooleanSelectEditor.vue
@@ -7,4 +7,8 @@
     import { ref, onMounted, computed } from 'vue'
     var kaas = ref('')
 
+    const props = defineProps({
+        property_shape: Object,
+    })
+
 </script>

--- a/src/components/DatePickerEditor.vue
+++ b/src/components/DatePickerEditor.vue
@@ -3,14 +3,13 @@
         <template v-slot:activator="{ props: activatorProps }">
             <v-btn
                 v-bind="activatorProps"
-                density="compact"
-                :text="selectedDate ? selectedDate.toISOString().split('T')[0] : 'Select a date'"
+                :text="graph[props.node_uid].properties[props.triple_uid].object ? graph[props.node_uid].properties[props.triple_uid].object.toISOString().split('T')[0] : 'Select a date'"
             ></v-btn>
         </template>
 
         <template v-slot:default="{ isActive }">
             <v-card title="Date">
-                <v-date-picker show-adjacent-months v-model="selectedDate"></v-date-picker>
+                <v-date-picker show-adjacent-months v-model="graph[props.node_uid].properties[props.triple_uid].object"></v-date-picker>
                 <v-card-actions>
                     <v-spacer></v-spacer>
                     <v-btn text="OK" @click="isActive.value = false"></v-btn>
@@ -22,12 +21,11 @@
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-    var today = new Date()
-    var today_date = today.toISOString().split('T')[0]
-    var selectedDate = ref(null)
-
+    const graph = inject('graph');
 </script>

--- a/src/components/DatePickerEditor.vue
+++ b/src/components/DatePickerEditor.vue
@@ -23,6 +23,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var today = new Date()
     var today_date = today.toISOString().split('T')[0]
     var selectedDate = ref(null)

--- a/src/components/DateTimePickerEditor.vue
+++ b/src/components/DateTimePickerEditor.vue
@@ -3,13 +3,13 @@
         <template v-slot:activator="{ props: activatorProps }">
             <v-btn
                 v-bind="activatorProps"
-                :text="selectedDate ? selectedDate.toISOString().split('T')[0] : 'Select a date'"
+                :text="graph[props.node_uid].properties[props.triple_uid].object ? graph[props.node_uid].properties[props.triple_uid].object.toISOString().split('T')[0] : 'Select a date'"
             ></v-btn>
         </template>
 
         <template v-slot:default="{ isActive }">
             <v-card title="Date">
-                <v-date-picker show-adjacent-months v-model="selectedDate"></v-date-picker>
+                <v-date-picker show-adjacent-months v-model="graph[props.node_uid].properties[props.triple_uid].object"></v-date-picker>
                 <v-card-actions>
                     <v-spacer></v-spacer>
                     <v-btn text="OK" @click="isActive.value = false"></v-btn>
@@ -21,12 +21,11 @@
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-    var today = new Date()
-    var today_date = today.toISOString().split('T')[0]
-    var selectedDate = ref(null)
-
+    const graph = inject('graph');
 </script>

--- a/src/components/DateTimePickerEditor.vue
+++ b/src/components/DateTimePickerEditor.vue
@@ -22,6 +22,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var today = new Date()
     var today_date = today.toISOString().split('T')[0]
     var selectedDate = ref(null)

--- a/src/components/DetailsEditor.vue
+++ b/src/components/DetailsEditor.vue
@@ -4,6 +4,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 
 </script>

--- a/src/components/DetailsEditor.vue
+++ b/src/components/DetailsEditor.vue
@@ -3,10 +3,11 @@
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-    var kaas = ref('')
-
+    const graph = inject('graph');
 </script>

--- a/src/components/InstancesSelectEditor.vue
+++ b/src/components/InstancesSelectEditor.vue
@@ -7,6 +7,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 
 </script>

--- a/src/components/InstancesSelectEditor.vue
+++ b/src/components/InstancesSelectEditor.vue
@@ -1,15 +1,17 @@
 <template>
     <v-autocomplete
         label="(instances select editor)"
+        v-model="graph[props.node_uid].properties[props.triple_uid].object"
         :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
     ></v-autocomplete>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-    var kaas = ref('')
-
+    const graph = inject('graph');
 </script>

--- a/src/components/NodeShapeEditor.vue
+++ b/src/components/NodeShapeEditor.vue
@@ -18,7 +18,9 @@
                             <p>{{ group[RDFS.comment.value] }}</p>
                             <br>
                             <span v-for="property in orderArrayOfObjects(group['own_properties'], SHACL.order.value)">
-                                <PropertyShapeEditor :property_shape="property" :prefixes="prefixes"/>
+                                <keep-alive>
+                                    <PropertyShapeEditor :key="props.shape_iri + '--' + property[SHACL.path.value]" :property_shape="property" :prefixes="prefixes" :node_uid="props.shape_iri"/>
+                                </keep-alive>
                             </span>
                             <br>
                         </v-tabs-window-item>
@@ -33,7 +35,9 @@
                 <p><em>{{ group[RDFS.comment.value] }}</em></p>
                 <br>
                 <span v-for="property in orderArrayOfObjects(group['own_properties'], SHACL.order.value)">
-                    <PropertyShapeEditor :property_shape="property" :prefixes="prefixes"/>
+                    <keep-alive>
+                        <PropertyShapeEditor :key="props.shape_iri + '--' + property[SHACL.path.value]" :property_shape="property" :prefixes="prefixes" :node_uid="props.shape_iri"/>
+                    </keep-alive>
                 </span>
                 <br>
             </span>
@@ -62,9 +66,9 @@
     const ready = ref(false)
     const sh_description = ref(SHACL.description.value)
     const defaultPropertyGroup = inject('defaultPropertyGroup');
-    const node_groups = ref([])
     var tab = ref(null)
-    const group_layout = ref('tabs') // or 'tabs'
+    // const group_layout = ref('tabs') // ref('default') or ref('tabs')
+    const group_layout = ref('default') // ref('default') or ref('tabs')
     
     // ----------------- //
     // Lifecycle methods //

--- a/src/components/NodeShapeEditor.vue
+++ b/src/components/NodeShapeEditor.vue
@@ -3,13 +3,40 @@
         <br>
         <p>{{ shape_obj[sh_description] }}</p>
         <br>
-        <span v-for="group in orderArrayOfObjects(Object.values(usedPropertyGroups), SHACL.order.value) ">
-            <h3>{{ group[RDFS.label.value] }}</h3>
-            <br>
-            <span v-for="property in orderArrayOfObjects(group['own_properties'], SHACL.order.value)">
-                <PropertyShapeEditor :property_shape="property" :prefixes="prefixes"/>
+        <span v-if="group_layout == 'tabs'">
+            <v-card>
+                <v-tabs v-model="tab" bg-color="#C5CAE9" >
+                    <span v-for="group in orderArrayOfObjects(Object.values(usedPropertyGroups), SHACL.order.value) ">
+                        <v-tab :value="group[RDFS.label.value]">{{ group[RDFS.label.value] }}</v-tab>
+                    </span>
+                </v-tabs>
+                <v-card-text>
+                <v-tabs-window v-model="tab">
+                    <span v-for="group in orderArrayOfObjects(Object.values(usedPropertyGroups), SHACL.order.value) ">
+                        <v-tabs-window-item :value="group[RDFS.label.value]">
+                            <h3>{{ group[RDFS.label.value] }}</h3>
+                            <p>{{ group[RDFS.comment.value] }}</p>
+                            <br>
+                            <span v-for="property in orderArrayOfObjects(group['own_properties'], SHACL.order.value)">
+                                <PropertyShapeEditor :property_shape="property" :prefixes="prefixes"/>
+                            </span>
+                            <br>
+                        </v-tabs-window-item>
+                    </span>
+                </v-tabs-window>
+                </v-card-text>
+            </v-card>
+        </span>
+        <span v-else>
+            <span v-for="group in orderArrayOfObjects(Object.values(usedPropertyGroups), SHACL.order.value) ">
+                <h3>{{ group[RDFS.label.value] }}</h3>
+                <p><em>{{ group[RDFS.comment.value] }}</em></p>
+                <br>
+                <span v-for="property in orderArrayOfObjects(group['own_properties'], SHACL.order.value)">
+                    <PropertyShapeEditor :property_shape="property" :prefixes="prefixes"/>
+                </span>
+                <br>
             </span>
-            <br>
         </span>
 </template>
 
@@ -36,6 +63,8 @@
     const sh_description = ref(SHACL.description.value)
     const defaultPropertyGroup = inject('defaultPropertyGroup');
     const node_groups = ref([])
+    var tab = ref(null)
+    const group_layout = ref('tabs') // or 'tabs'
     
     // ----------------- //
     // Lifecycle methods //
@@ -146,7 +175,6 @@
         group_instances = [...new Set(group_instances)].filter( Boolean )
         console.log("group_instances")
         console.log(group_instances)
-
     }
 
 </script>

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -8,23 +8,26 @@
                 </span>
             </v-col>
             <v-col cols="6">
-                <component
-                    :is="matchedComponent.comp"
-                    :property_shape="property_shape"
-                    :comp_uid="my_uid"
-                    >
-                </component>
+                <span v-if="isTripleAdded">
+                    <keep-alive>
+                        <component
+                            :is="matchedComponent.comp"
+                            :property_shape="property_shape"
+                            :node_uid="props.node_uid"
+                            :triple_uid="my_uid"
+                            >
+                        </component>
+                    </keep-alive>
+                </span>
             </v-col>
             <v-col></v-col>
         </v-row>
 </template>
 
 <script setup>
-    import { ref, onMounted, onBeforeMount, computed, inject} from 'vue'
+    import { ref, onMounted, onBeforeMount, computed, inject, onBeforeUpdate} from 'vue'
     import {SHACL, RDF, DASH, XSD} from '../plugins/namespaces'
-    import { matchers } from '../plugins/globals'
-    import { v4 as uuidv4 } from 'uuid';
-    
+    import { matchers } from '../plugins/globals'    
     
     // ----- //
     // Props //
@@ -33,22 +36,32 @@
     const props = defineProps({
         property_shape: Object,
         prefixes: Object,
+        node_uid: String,
     })
 
     // ---- //
     // Data //
     // ---- //
     const my_uid = ref('');
-    const graph = inject('graph');
     const add_triple = inject('add_triple');
+    const isTripleAdded = ref(false);
 
     // ----------------- //
     // Lifecycle methods //
     // ----------------- //
 
+    onMounted(() => {
+    })
+
     onBeforeMount(() => {
-        my_uid.value = uuidv4();
-        add_triple(my_uid.value)
+        console.log("PropertyShapeEditor is about to mounted")
+        my_uid.value = props.node_uid + '--' + props.property_shape[SHACL.path.value]
+        add_triple(props.node_uid, my_uid.value)
+        isTripleAdded.value = true;
+    })
+
+    onBeforeUpdate(() => {
+        console.log(`PropertyShapeEditor is about to be updated: ${my_uid.value}`)
     })
 
     // ------------------- //

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -7,15 +7,23 @@
                     </v-tooltip>
                 </span>
             </v-col>
-            <v-col cols="6"><component :is="matchedComponent.comp" :property_shape="property_shape"></component></v-col>
+            <v-col cols="6">
+                <component
+                    :is="matchedComponent.comp"
+                    :property_shape="property_shape"
+                    :comp_uid="my_uid"
+                    >
+                </component>
+            </v-col>
             <v-col></v-col>
         </v-row>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import { ref, onMounted, onBeforeMount, computed, inject} from 'vue'
     import {SHACL, RDF, DASH, XSD} from '../plugins/namespaces'
     import { matchers } from '../plugins/globals'
+    import { v4 as uuidv4 } from 'uuid';
     
     
     // ----- //
@@ -25,6 +33,22 @@
     const props = defineProps({
         property_shape: Object,
         prefixes: Object,
+    })
+
+    // ---- //
+    // Data //
+    // ---- //
+    const my_uid = ref('');
+    const graph = inject('graph');
+    const add_triple = inject('add_triple');
+
+    // ----------------- //
+    // Lifecycle methods //
+    // ----------------- //
+
+    onBeforeMount(() => {
+        my_uid.value = uuidv4();
+        add_triple(my_uid.value)
     })
 
     // ------------------- //

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -3,11 +3,11 @@
             <v-col cols="3">
                 <span>{{ nameOrCURIE }}:
                     <v-tooltip activator="parent" location="right" max-width="400px" max-height="400px">
-                        {{ props.property_shape[SHACL.name.value] }}: {{ props.property_shape[SHACL.description.value] }}
+                        {{ props.property_shape[SHACL.description.value] }}
                     </v-tooltip>
                 </span>
             </v-col>
-            <v-col cols="6"><component :is="matchedComponent.comp"></component></v-col>
+            <v-col cols="6"><component :is="matchedComponent.comp" :property_shape="property_shape"></component></v-col>
             <v-col></v-col>
         </v-row>
 </template>

--- a/src/components/TextAreaEditor.vue
+++ b/src/components/TextAreaEditor.vue
@@ -4,6 +4,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 
 </script>

--- a/src/components/TextAreaEditor.vue
+++ b/src/components/TextAreaEditor.vue
@@ -1,12 +1,13 @@
 <template>
-    <v-textarea v-bind="props.object" variant="outlined" label="(text area editor)"></v-textarea>
+    <v-textarea v-model="graph[props.node_uid].properties[props.triple_uid].object" variant="outlined" label="(text area editor)"></v-textarea>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
-        object: String,
+        node_uid: String,
+        triple_uid: String
     })
-
+    const graph = inject('graph');
 </script>

--- a/src/components/TextAreaEditor.vue
+++ b/src/components/TextAreaEditor.vue
@@ -1,12 +1,12 @@
 <template>
-    <v-textarea v-bind="kaas" variant="outlined" label="(text area editor)"></v-textarea>
+    <v-textarea v-bind="props.object" variant="outlined" label="(text area editor)"></v-textarea>
 </template>
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
     const props = defineProps({
         property_shape: Object,
+        object: String,
     })
-    var kaas = ref('')
 
 </script>

--- a/src/components/TextFieldEditor.vue
+++ b/src/components/TextFieldEditor.vue
@@ -4,5 +4,8 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 </script>

--- a/src/components/TextFieldEditor.vue
+++ b/src/components/TextFieldEditor.vue
@@ -1,11 +1,15 @@
 <template>
-    <v-text-field v-bind="kaas" density="compact" variant="outlined" label="(text field editor)"></v-text-field>
+    <v-text-field v-bind="props.object" density="compact" variant="outlined" label="(text field editor)"></v-text-field>
 </template>
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+
+    // ----- //
+    // Props //
+    // ----- //
     const props = defineProps({
         property_shape: Object,
+        object: String,
     })
-    var kaas = ref('')
 </script>

--- a/src/components/TextFieldEditor.vue
+++ b/src/components/TextFieldEditor.vue
@@ -1,15 +1,13 @@
 <template>
-    <v-text-field v-bind="props.object" density="compact" variant="outlined" label="(text field editor)"></v-text-field>
+    <v-text-field v-model="graph[props.node_uid].properties[props.triple_uid].object" density="compact" variant="outlined" label="(text field editor)"></v-text-field>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
-
-    // ----- //
-    // Props //
-    // ----- //
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
-        object: String,
+        node_uid: String,
+        triple_uid: String
     })
+    const graph = inject('graph');
 </script>

--- a/src/components/URIEditor.vue
+++ b/src/components/URIEditor.vue
@@ -1,12 +1,13 @@
 <template>
-    <v-text-field v-model="graph[props.comp_uid].object" density="compact" variant="outlined" label="(URI editor)"></v-text-field>
+    <v-text-field v-model="graph[props.node_uid].properties[props.triple_uid].object" density="compact" variant="outlined" label="(URI editor)"></v-text-field>
 </template>
 
 <script setup>
-    import { ref, inject, watch} from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
-        comp_uid: String
+        node_uid: String,
+        triple_uid: String
     })
     const graph = inject('graph');
 </script>

--- a/src/components/URIEditor.vue
+++ b/src/components/URIEditor.vue
@@ -4,5 +4,8 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 </script>

--- a/src/components/URIEditor.vue
+++ b/src/components/URIEditor.vue
@@ -1,11 +1,12 @@
 <template>
-    <v-text-field v-bind="kaas" density="compact" variant="outlined" label="(URI editor)"></v-text-field>
+    <v-text-field v-model="graph[props.comp_uid].object" density="compact" variant="outlined" label="(URI editor)"></v-text-field>
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import { ref, inject, watch} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        comp_uid: String
     })
-    var kaas = ref('')
+    const graph = inject('graph');
 </script>

--- a/src/components/UnknownEditor.vue
+++ b/src/components/UnknownEditor.vue
@@ -4,6 +4,9 @@
 
 <script setup>
     import { ref, onMounted, computed } from 'vue'
+    const props = defineProps({
+        property_shape: Object,
+    })
     var kaas = ref('')
 
 </script>

--- a/src/components/UnknownEditor.vue
+++ b/src/components/UnknownEditor.vue
@@ -3,10 +3,11 @@
 </template>
 
 <script setup>
-    import { ref, onMounted, computed } from 'vue'
+    import {inject} from 'vue'
     const props = defineProps({
         property_shape: Object,
+        node_uid: String,
+        triple_uid: String
     })
-    var kaas = ref('')
-
+    const graph = inject('graph');
 </script>

--- a/src/composables/base.js
+++ b/src/composables/base.js
@@ -1,0 +1,23 @@
+// base.js
+import { reactive, ref, onMounted, onUnmounted } from 'vue'
+import { v4 as uuidv4 } from 'uuid';
+
+// by convention, composable function names start with "use"
+export function useBaseComponent() {
+
+  var my_uid = ref(null)
+
+  function assignUUID() {
+    my_uid = uuidv4();
+  }
+
+  onMounted(() => {
+    console.log("Component mounted, assigning UUID from composable code:\n")
+    assignUUID()
+    console.log(my_uid)
+  });
+
+  return {
+    my_uid
+  }
+}

--- a/src/composables/graphdata.js
+++ b/src/composables/graphdata.js
@@ -1,0 +1,35 @@
+// graphdata.js
+import { reactive, ref, onMounted, onUnmounted } from 'vue'
+
+// by convention, composable function names start with "use"
+export function useGraph() {
+  // state encapsulated and managed by the composable
+
+  const graph = reactive({})
+
+  // a composable can update its managed state over time.
+  function add_triple(node_uid) {
+    graph[node_uid] = {
+      subject: ref(""),
+      predicate: ref(""),
+      object: ref("")
+    }
+  }
+
+  function remove_triple(node_uid) {
+    delete graph[node_uid]
+  }
+
+  function edit_triple(node_uid, part, newVal) {
+    console.log("editing triple from composable")
+    graph[node_uid][part] = newVal
+  }
+
+  // expose managed state as return value
+  return {
+    graph,
+    add_triple,
+    remove_triple,
+    edit_triple
+  }
+}

--- a/src/composables/graphdata.js
+++ b/src/composables/graphdata.js
@@ -8,11 +8,37 @@ export function useGraph() {
   const graph = reactive({})
 
   // a composable can update its managed state over time.
-  function add_triple(node_uid) {
-    graph[node_uid] = {
-      subject: ref(""),
-      predicate: ref(""),
-      object: ref("")
+  function add_triple(node_uid, triple_uid) {
+
+    // if the  node uid exists and the triple does not exist, add it
+    if (Object.keys(graph).indexOf(node_uid) >= 0) {
+      if (Object.keys(graph[node_uid].properties).indexOf(triple_uid) < 0) {
+        graph[node_uid].properties[triple_uid] = {
+          subject: ref(null),
+          predicate: ref(null),
+          object: ref(null)
+        }
+        console.log(`Added triple to graph: ${triple_uid} -> ${node_uid}`)
+      } else {
+        console.log(`Triple UID already in graph: ${triple_uid}`)
+      }
+    } else {
+      console.log(`Node UID not in graph yet: ${node_uid}. not doing anything...`)
+    }
+  }
+
+
+  function add_node(node_uid) {
+    if (Object.keys(graph).indexOf(node_uid) < 0) {
+      graph[node_uid] = {
+        subject: ref(null),
+        predicate: ref(null),
+        object: ref(null),
+        properties: ref({}),
+      }
+      console.log(`Added node to graph: ${node_uid}`)
+    } else {
+      console.log(`Node UID already in graph: ${node_uid}`)
     }
   }
 
@@ -29,6 +55,7 @@ export function useGraph() {
   return {
     graph,
     add_triple,
+    add_node,
     remove_triple,
     edit_triple
   }

--- a/src/main.js
+++ b/src/main.js
@@ -17,4 +17,4 @@ const app = createApp(App)
 
 registerPlugins(app)
 
-app.mount('#app')
+app.mount('#app');

--- a/src/modules/graphdata.js
+++ b/src/modules/graphdata.js
@@ -1,0 +1,3 @@
+import rdf from 'rdf-ext';
+
+shapesDataset = rdf.dataset()


### PR DESCRIPTION
Including:
- Updated shacl schema from which the UI is generated
- Ability to specify how groups should be displayed in the node editor: default is top-down, alternative is a tab per group
- Introduce a composable with globally graph data that is written to from editors, and which uses provide/inject to make the data object available to the tree of components.
- Creating a structure for the graph data that depends on shacl nodes and properties
- updating all editor components to accept the correct props and create entries in the graph data in the correct way
- displaying entered data in the UI, as ttl
- adding a style sheet