### PR TITLE
Towards an improved structure for graph data loading and traversal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,7 +28,36 @@
 
 
 <script setup>
-  import { ref } from 'vue'
+  import { ref, provide, onMounted} from 'vue';
+  import { useGraphData } from '@/composables/graphdata';
+  import { DLTHING, XSD } from '@/modules/namespaces';
+  import rdf from 'rdf-ext';
+
   var tab = ref(1)
+
+  const { graphData, getGraphData, graphPrefixes, serializedGraphData, graphTriples } = useGraphData()
+
+  provide('graphData', graphData)
+  provide('serializedGraphData', serializedGraphData)
+  provide('graphTriples', graphTriples)
+  provide('graphPrefixes', graphPrefixes)
+
+
+  onMounted( async () => {
+    console.log("App.vue async onmounted...")
+    const penguins = new URL("@/assets/distribution-penguins.ttl", import.meta.url).href
+    await getGraphData(penguins)
+
+    console.log(graphTriples.length)
+    console.log(graphData.size)
+    
+    const mypersonB = rdf.grapoi({ dataset: graphData })
+      .hasOut(DLTHING.meta_type, rdf.literal('dldist:Person', XSD.anyURI))
+      .quads();
+    console.log('Persons in Penguin Dataset, using literal in query:')
+    for (const quad of mypersonB) {
+      console.log(`\t${quad.subject.value}`)
+    }
+  })
   
 </script>

--- a/src/assets/distribution-penguins.ttl
+++ b/src/assets/distribution-penguins.ttl
@@ -1,0 +1,208 @@
+@prefix CiTO: <http://purl.org/spar/cito/> .
+@prefix dldist: <https://concepts.datalad.org/s/distribution/unreleased/> .
+@prefix dlprov: <https://concepts.datalad.org/s/prov/unreleased/> .
+@prefix dlsdd: <https://concepts.datalad.org/s/sdd/unreleased/> .
+@prefix dlthing: <https://concepts.datalad.org/s/thing/unreleased/> .
+@prefix dpv: <https://w3id.org/dpv#> .
+@prefix licenses: <http://spdx.org/licenses/> .
+@prefix marcrel: <http://id.loc.gov/vocabulary/relators/> .
+@prefix schema1: <http://schema.org/> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://example.org/ns/datasetversion/.> dldist:has_part <https://example.org/ns/datasetversion/./adelie.csv>,
+        <https://example.org/ns/datasetversion/./chinstrap.csv>,
+        <https://example.org/ns/datasetversion/./gentoo.csv> ;
+    dldist:is_distribution_of <https://example.org/ns/datasetversion/#> ;
+    dldist:license licenses:CC0-1.0 ;
+    dldist:qualified_part [ a dldist:DistributionPart ;
+            dlprov:entity <https://example.org/ns/datasetversion/./gentoo.csv> ;
+            dlthing:name "gentoo.csv" ],
+        [ a dldist:DistributionPart ;
+            dlprov:entity <https://example.org/ns/datasetversion/./chinstrap.csv> ;
+            dlthing:name "chinstrap.csv" ],
+        [ a dldist:DistributionPart ;
+            dlprov:entity <https://example.org/ns/datasetversion/./adelie.csv> ;
+            dlthing:name "adelie.csv" ] ;
+    dlprov:relation <https://example.org/ns/dataset/#RStudio>,
+        <https://example.org/ns/dataset/#UCSB>,
+        <https://example.org/ns/dataset/#ahill>,
+        <https://example.org/ns/dataset/#ahorst>,
+        <https://example.org/ns/dataset/#gormanetal>,
+        <https://example.org/ns/dataset/#kgorman>,
+        <https://example.org/ns/dataset/#nsf0217282>,
+        <https://example.org/ns/dataset/#nsf0741351>,
+        <https://example.org/ns/dataset/#nsf0823101>,
+        <https://example.org/ns/datasetversion/#>,
+        <https://ror.org/01j7nq853>,
+        <https://ror.org/021nxhr62>,
+        <https://ror.org/05nwjp114> ;
+    dlprov:was_attributed_to <https://example.org/ns/dataset/#RStudio>,
+        <https://example.org/ns/dataset/#UCSB>,
+        <https://example.org/ns/dataset/#ahill>,
+        <https://example.org/ns/dataset/#ahorst>,
+        <https://example.org/ns/dataset/#kgorman>,
+        <https://ror.org/01j7nq853>,
+        <https://ror.org/021nxhr62>,
+        <https://ror.org/05nwjp114> ;
+    dlthing:meta_type "dldist:Distribution"^^xsd:anyURI .
+
+<https://example.org/ns/dataset/#gormanetal> dldist:date_published "2014-03-05"^^<https://www.w3.org/TR/NOTE-datetime> ;
+    dlprov:qualified_attribution [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#kgorman> ;
+            dlprov:had_role marcrel:aut ] ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "10.1371/journal.pone.0090081" ;
+            dlthing:schema_agency <https://doi.org> ] ;
+    dlthing:meta_type "dlsdd:Publication"^^xsd:anyURI ;
+    dlthing:notation "'Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081.'" .
+
+<https://example.org/ns/dataset/#nsf0217282> dlsdd:cites_as_authority "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0217282"^^xsd:anyURI ;
+    dlsdd:sponsor <https://ror.org/05nwjp114> ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0217282" ;
+            dlthing:schema_agency <https://ror.org/021nxhr62> ] ;
+    dlthing:meta_type "dlsdd:Grant"^^xsd:anyURI ;
+    dlthing:name "LTER: PALMER, ANTARCTICA LTER: Climate Change, Ecosystem Migration and Teleconnections in an Ice-Dominated Environment" .
+
+<https://example.org/ns/dataset/#nsf0741351> dlsdd:cites_as_authority "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0741351"^^xsd:anyURI ;
+    dlsdd:sponsor <https://ror.org/05nwjp114> ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0741351" ;
+            dlthing:schema_agency <https://ror.org/021nxhr62> ] ;
+    dlthing:meta_type "dlsdd:Grant"^^xsd:anyURI ;
+    dlthing:name "Collaborative Research: Possible Climate-induced Change in the Distribution of Pleuragramma Antarcticum on the Western Antarctic Peninsula Shelf" .
+
+<https://example.org/ns/dataset/#nsf0823101> dlsdd:cites_as_authority "https://www.nsf.gov/awardsearch/showAward?AWD_ID=0823101"^^xsd:anyURI ;
+    dlsdd:sponsor <https://ror.org/05nwjp114> ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0823101" ;
+            dlthing:schema_agency <https://ror.org/021nxhr62> ] ;
+    dlthing:meta_type "dlsdd:Grant"^^xsd:anyURI ;
+    dlthing:name "Palmer, Antarctica Long Term Ecological Research Project" .
+
+<https://example.org/ns/datasetversion/#> dldist:date_modified "2020-07-16"^^<https://www.w3.org/TR/NOTE-datetime> ;
+    dldist:is_version_of <https://example.org/ns/dataset/#> ;
+    dldist:keyword "animal sexual behavior",
+        "antarctica",
+        "ecological niches",
+        "foraging",
+        "islands",
+        "isotopes",
+        "penguins",
+        "sea ice" ;
+    dldist:landing_page "https://github.com/allisonhorst/palmerpenguins"^^xsd:anyURI ;
+    dldist:version "0.1.0" ;
+    dlprov:qualified_attribution [ a dlprov:Attribution ;
+            dlprov:agent <https://ror.org/01j7nq853> ;
+            dlprov:had_role marcrel:sht ],
+        [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#RStudio> ;
+            dlprov:had_role marcrel:sht ],
+        [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#UCSB> ;
+            dlprov:had_role marcrel:sht ],
+        [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#ahorst> ;
+            dlprov:had_role marcrel:aut,
+                dpv:DataController ],
+        [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#kgorman> ;
+            dlprov:had_role marcrel:aut,
+                marcrel:cre ],
+        [ a dlprov:Attribution ;
+            dlprov:agent <https://example.org/ns/dataset/#ahill> ;
+            dlprov:had_role marcrel:aut ] ;
+    dlprov:qualified_relation [ dlprov:entity <https://example.org/ns/dataset/#nsf0217282>,
+                <https://example.org/ns/dataset/#nsf0741351>,
+                <https://example.org/ns/dataset/#nsf0823101> ;
+            dlprov:had_role schema1:funding ;
+            dlthing:meta_type "dlprov:EntityInfluence"^^xsd:anyURI ],
+        [ dlprov:entity <https://example.org/ns/dataset/#gormanetal> ;
+            dlprov:had_role CiTO:citesAsAuthority,
+                CiTO:isCitedAsDataSourceBy ;
+            dlthing:meta_type "dlprov:EntityInfluence"^^xsd:anyURI ] ;
+    dlthing:description "The goal of palmerpenguins is to provide a great dataset for data exploration and visualization, as an alternative to iris. Data were collected and made available by Dr. Kristen Gorman and the Palmer Station, Antarctica LTER, a member of the Long Term Ecological Research Network." ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "10.5281/zenodo.3960218" ;
+            dlthing:schema_agency <https://doi.org> ] ;
+    dlthing:meta_type "dldist:Resource"^^xsd:anyURI ;
+    dlthing:name "penguins" ;
+    dlthing:same_as "https://doi.org/10.5281/zenodo.3960218"^^xsd:anyURI ;
+    dlthing:title "Palmer Penguins" .
+
+<https://example.org/ns/datasetversion/./adelie.csv> dldist:byte_size "23755"^^xsd:nonNegativeInteger ;
+    dldist:checksum [ a dldist:Checksum ;
+            spdx:algorithm "md5"^^xsd:anyURI ;
+            dldist:digest "e7e2be6b203a221949f05e02fcefd853"^^xsd:hexBinary ] ;
+    dldist:download_url "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff"^^xsd:anyURI ;
+    dldist:media_type "text/csv" ;
+    dlthing:meta_type "dldist:Distribution"^^xsd:anyURI .
+
+<https://example.org/ns/datasetversion/./chinstrap.csv> dldist:byte_size "18872"^^xsd:nonNegativeInteger ;
+    dldist:checksum [ a dldist:Checksum ;
+            spdx:algorithm "md5"^^xsd:anyURI ;
+            dldist:digest "e4b0710c69297031d63866ce8b888f25"^^xsd:hexBinary ] ;
+    dldist:download_url "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462"^^xsd:anyURI ;
+    dldist:media_type "text/csv" ;
+    dlthing:meta_type "dldist:Distribution"^^xsd:anyURI .
+
+<https://example.org/ns/datasetversion/./gentoo.csv> dldist:byte_size "11263"^^xsd:nonNegativeInteger ;
+    dldist:checksum [ a dldist:Checksum ;
+            spdx:algorithm "md5"^^xsd:anyURI ;
+            dldist:digest "1549566fb97afa879dc9446edcf2015f"^^xsd:hexBinary ] ;
+    dldist:download_url "https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381"^^xsd:anyURI ;
+    dldist:media_type "text/csv" ;
+    dlthing:meta_type "dldist:Distribution"^^xsd:anyURI .
+
+<https://example.org/ns/dataset/#RStudio> dlthing:meta_type "dldist:Organization"^^xsd:anyURI ;
+    dlthing:name "RStudio: Boston, MA, US" .
+
+<https://example.org/ns/dataset/#ahill> dldist:affiliation <https://example.org/ns/dataset/#Rstudio> ;
+    dldist:email "ahill@example.com"^^dldist:EmailAddress ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0000-0002-8082-1890" ;
+            dlthing:schema_agency <https://orcid.org> ] ;
+    dlthing:meta_type "dldist:Person"^^xsd:anyURI ;
+    dlthing:name "Allison Hill" .
+
+<https://example.org/ns/dataset/#ahorst> dldist:affiliation <https://example.org/ns/dataset/#UCSB> ;
+    dldist:email "ahorst@example.com"^^dldist:EmailAddress ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0000-0002-6047-5564" ;
+            dlthing:schema_agency <https://orcid.org> ] ;
+    dlthing:meta_type "dldist:Person"^^xsd:anyURI ;
+    dlthing:name "Allison Horst" ;
+    dlthing:same_as "https://orcid.org/0000-0002-6047-5564"^^xsd:anyURI .
+
+<https://example.org/ns/dataset/#UCSB> dlthing:meta_type "dldist:Organization"^^xsd:anyURI ;
+    dlthing:name "UC Santa Barbara: Santa Barbara, CA, US" .
+
+<https://example.org/ns/dataset/#kgorman> dldist:affiliation <https://ror.org/01j7nq853> ;
+    dldist:email "kgorman@example.com"^^dldist:EmailAddress ;
+    dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "0000-0002-0258-9264" ;
+            dlthing:schema_agency <https://orcid.org> ] ;
+    dlthing:meta_type "dldist:Person"^^xsd:anyURI ;
+    dlthing:name "Kirsten Gorman" .
+
+<https://ror.org/01j7nq853> dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "01j7nq853" ;
+            dlthing:schema_agency <https://ror.org> ] ;
+    dlthing:meta_type "dldist:Organization"^^xsd:anyURI ;
+    dlthing:name "University of Alaska Fairbanks: Fairbanks, AK, US" .
+
+<https://ror.org/021nxhr62> dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "021nxhr62" ;
+            dlthing:schema_agency <https://ror.org> ] ;
+    dlthing:meta_type "dlthing:Thing"^^xsd:anyURI ;
+    dlthing:name "US National Science Foundation" ;
+    dlthing:same_as "https://www.nsf.org"^^xsd:anyURI .
+
+<https://ror.org/05nwjp114> dlthing:identifier [ a dlthing:Identifier ;
+            dlthing:notation "05nwjp114" ;
+            dlthing:schema_agency <https://ror.org> ] ;
+    dlthing:meta_type "dlthing:Thing"^^xsd:anyURI ;
+    dlthing:name "NSF Office of Polar Programs" .
+
+

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1,3 +1,10 @@
 code {
     font-size: 12px;
 }
+.formatted-pre {
+    white-space:normal;
+    overflow-x: scroll;
+}
+.formatted-code {
+    white-space:pre;
+}

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -20,7 +20,3 @@
     </template>
   </v-app-bar>
 </template>
-
-<script setup>
-  //
-</script>

--- a/src/components/InstancesSelectEditor.vue
+++ b/src/components/InstancesSelectEditor.vue
@@ -2,15 +2,21 @@
     <v-autocomplete
         label="(instances select editor)"
         v-model="formData[props.node_uid][props.triple_uid]"
-        :items="['California', 'Colorado', 'Florida', 'Georgia', 'Texas', 'Wyoming']"
+        :items="instanceItems"
         validate-on="lazy input"
         :rules="rules"
     ></v-autocomplete>
 </template>
 
 <script setup>
-    import { inject } from 'vue'
+    import { inject, reactive, onMounted, ref, computed} from 'vue'
     import { useRules } from '../composables/rules'
+    import rdf from 'rdf-ext'
+    import {SHACL, RDF, DLTHING, XSD} from '@/modules/namespaces'
+    import { toCURIE } from '../modules/utils';
+
+    const predicateSelector = DLTHING.meta_type
+    // const predicateSelector = RDF.type.value
 
     const props = defineProps({
         property_shape: Object,
@@ -18,12 +24,41 @@
         triple_uid: String,
     })
     const formData = inject('formData');
+    const graphData = inject('graphData');
+    const graphPrefixes = inject('graphPrefixes');
+    const shapePrefixes = inject('shapePrefixes');
     const { rules } = useRules(props.property_shape)
+    // var classNodes = reactive(null)
+    // var classNodes2 = reactive(null)
+    var propClass = ref(null)
+    const combinedQuads = reactive([])
+    const instanceItems = reactive([])
+
+    onMounted(() => {
+        console.log(`\nMounted InstancesSelectEditor: ${props.property_shape[SHACL.path.value]} (graphdata is ${graphData.size})`)
+        propClass.value = props.property_shape[SHACL.class.value] ?? false // TODO: what should the correct default value be here?
+
+        let allprefixes = {...shapePrefixes, ...graphPrefixes};
+        var propClassCurie = toCURIE(propClass.value, allprefixes)
+        const literalNodes = rdf.grapoi({ dataset: graphData })
+            .hasOut(predicateSelector, rdf.literal(String(propClassCurie), XSD.anyURI))
+            .quads();
+        const uriNodes = rdf.grapoi({ dataset: graphData })
+            .hasOut(predicateSelector, propClass.value)
+            .quads();
+        const combinedQuads = Array.from(literalNodes).concat(Array.from(uriNodes));
+        console.log("Concatenated results")
+        combinedQuads.forEach(quad => {
+            console.log(`\t${quad.subject.value}`)
+            instanceItems.push(quad.subject.value)
+        });
+    })
+
 </script>
 
 
 <script>
-    import { SHACL } from '../modules/namespaces'
+    import { SHACL } from '@/modules/namespaces'
     export const matchingLogic = (shape) => {
         // sh:nodeKind exists
         if ( shape.hasOwnProperty(SHACL.nodeKind.value) ) {

--- a/src/components/MainData.vue
+++ b/src/components/MainData.vue
@@ -8,13 +8,13 @@
             <v-file-input
               density="compact"
               variant="outlined"
+              v-model="upload_url"
               accept="*.ttl"
               label="Upload a ttl file"
               chips
               validate-on="input"
             ></v-file-input>
           </v-form>
-
         </v-col>
         <v-col cols="1" style="text-align: center;">...or...</v-col>
         <v-col>
@@ -25,11 +25,14 @@
               variant="outlined"
               type="url"
               label="Paste a public URL"
-              validate-on="lazy input"
+              validate-on="input"
             >
             </v-text-field>
           </v-form>
         </v-col>
+      </v-row>
+      <v-row align="start" no-gutters>
+        <v-btn text="Load data" @click="getGraphData(public_url)"></v-btn>
       </v-row>
 
       
@@ -37,18 +40,41 @@
     </v-sheet>
     <br>
     <h3>Data Graph</h3>
+    
     <v-sheet class="pa-4" border rounded elevation="2">
-      <code>
-
-      </code>
+      <suspense>
+        <pre class="formatted-pre">
+          <code class="formatted-code">{{ serializedGraphData }}</code>
+        </pre>
+      </suspense>
     </v-sheet>
+
+    <br>
+
+    <v-sheet class="pa-4" border rounded elevation="2">
+      <Suspense>
+        <pre class="formatted-pre">
+          <code class="formatted-code">
+            <span v-for="trip in graphTriples">
+              {{ trip }}
+            </span>
+          </code>
+        </pre>
+      </Suspense>
+    </v-sheet>
+
+
   </v-container>
 </template>
 
 
 <script setup>
-  import { ref, onMounted, onBeforeMount, provide } from 'vue'
-
+  import { ref, computed, onMounted, inject } from 'vue'
+  const graphData = inject('graphData');
+  const serializedGraphData = inject('serializedGraphData');
+  const graphTriples = inject('graphTriples');
   const public_url = ref('')
-  
+  const upload_url = ref(null)
+
+
 </script>

--- a/src/components/MainForm.vue
+++ b/src/components/MainForm.vue
@@ -5,7 +5,7 @@
         <h3>Forms</h3>
         <v-select v-if="prefixes_ready" :items="nodeShapeNamesArray" item-title="name" label="Select" density="compact">
           <template v-slot:item="{ props, item }">
-            <v-list-item v-bind="props" :title="toCURIE(nodeShapeNames[item.raw], prefixes)" @click="selectIRI(nodeShapeNames[item.raw])"></v-list-item>
+            <v-list-item v-bind="props" :title="toCURIE(nodeShapeNames[item.raw], shapePrefixes)" @click="selectIRI(nodeShapeNames[item.raw])"></v-list-item>
           </template>
         </v-select>
       </v-col>
@@ -27,17 +27,17 @@
             <h3>Form data</h3>
             <v-sheet class="pa-4" border rounded elevation="2">
               <code>
-                <span v-for="(value, key, index) in prefixes">
+                <span v-for="(value, key, index) in shapePrefixes">
                   @prefix {{ key }}: &lt;{{ value }}&gt; .<br>
                 </span>
                 <br>
                 <span v-for="(value, key, index) in formData">
                   _b{{ index }} <br>
-                  &nbsp;&nbsp;&nbsp; a {{ toCURIE(key, prefixes) }}
+                  &nbsp;&nbsp;&nbsp; a {{ toCURIE(key, shapePrefixes) }}
                   <span v-for="(prop_val, prop_key , prop_idx) in value">
                     <span v-if="prop_val">
                         ; <br>
-                      &nbsp;&nbsp;&nbsp; {{ toCURIE(prop_key, prefixes) }} &quot;{{  prop_val }}&quot;
+                      &nbsp;&nbsp;&nbsp; {{ toCURIE(prop_key, shapePrefixes) }} &quot;{{  prop_val }}&quot;
                     </span>
                   </span> .
                   <br><br>
@@ -52,7 +52,7 @@
 
 
 <script setup>
-  import { ref, onMounted, onBeforeMount, provide } from 'vue'
+  import { ref, onMounted, onBeforeMount, provide, inject} from 'vue'
   import { useFormData } from '@/composables/formdata';
   import { useShapeData } from '@/composables/shapedata';
   import { toCURIE } from '@/modules/utils';
@@ -74,7 +74,7 @@
     nodeShapes,
     propertyGroups,
     nodeShapeNamesArray,
-    prefixes,
+    shapePrefixes,
     prefixArray,
     prefixes_ready,
     nodeShapeIRIs,
@@ -94,7 +94,7 @@
   provide('add_node', add_node)
   provide('remove_triple', remove_triple)
   provide('edit_triple', edit_triple)
-  provide('prefixes', prefixes)
+  provide('shapePrefixes', shapePrefixes)
   provide('editorMatchers', editorMatchers)
   provide('defaultEditor', defaultEditor)
 

--- a/src/components/NodeShapeEditor.vue
+++ b/src/components/NodeShapeEditor.vue
@@ -1,5 +1,5 @@
 <template>
-    <h2>{{ toCURIE(shape_iri, prefixes) }}</h2>
+    <h2>{{ toCURIE(shape_iri, shapePrefixes) }}</h2>
     <br>
     <p>{{ shape_obj[sh_description] }}</p>
     <br>
@@ -66,7 +66,7 @@
     // ---- //
 
     const ready = ref(false)
-    const prefixes = inject('prefixes');
+    const shapePrefixes = inject('shapePrefixes');
     const sh_description = ref(SHACL.description.value)
     const defaultPropertyGroup = inject('defaultPropertyGroup');
     var tab = ref(null)

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -45,7 +45,7 @@
 
     const my_uid = ref('');
     const add_triple = inject('add_triple');
-    const prefixes = inject('prefixes');
+    const shapePrefixes = inject('shapePrefixes');
     const editorMatchers = inject('editorMatchers');
     const defaultEditor = inject('defaultEditor');
     const isTripleAdded = ref(false);
@@ -78,7 +78,7 @@
         if (props.property_shape.hasOwnProperty(SHACL.name.value)) {
             return props.property_shape[SHACL.name.value]
         } else {
-            return toCURIE(props.property_shape[SHACL.path.value], prefixes)   
+            return toCURIE(props.property_shape[SHACL.path.value], shapePrefixes)   
         }
     });
 

--- a/src/composables/graphdata.js
+++ b/src/composables/graphdata.js
@@ -1,0 +1,54 @@
+// graphdata.js
+import { reactive, ref } from 'vue'
+import { readRDF } from '@/modules/io'
+import rdf from 'rdf-ext';
+import formatsPretty from '@rdfjs/formats/pretty.js'
+
+export function useGraphData() {
+
+  const graphData = reactive(rdf.dataset())
+  const serializedGraphData = ref('')
+  var graphPrefixes = reactive({});
+	var prefixArray = ref([]);
+	var prefixes_ready = ref(false);
+  const rdfPretty = rdf.clone()
+  rdfPretty.formats.import(formatsPretty)
+  var graphTriples = ref([]);
+
+
+  async function getGraphData(url) {
+		readRDF(url)
+		.then(quadStream => {
+			// Load prefixes
+			quadStream.on('prefix', (prefix, ns) => {
+				graphPrefixes[prefix] = ns.value;
+				prefixArray.value.push(ns.value)
+			}).on('end', () => {
+				prefixes_ready.value = true
+			})
+			// Load data
+			quadStream.on('data', quad => {
+				graphData.add(quad)
+			}).on('end', async () => {
+        console.log('--- Graph Data ---')
+        console.log(graphData)
+        serializedGraphData.value = (await rdfPretty.io.dataset.toText('text/turtle', graphData)).trim()
+        graphData.forEach(quad => {
+          graphTriples.value.push(`${quad.subject.value} - ${quad.predicate.value} - ${quad.object.value}`)
+        });
+      });
+		})
+		.catch(error => {
+			console.error('Error reading TTL data:', error);
+		});
+	}
+
+  // expose managed state as return value
+  return {
+    graphData,
+    getGraphData,
+    graphPrefixes,
+    serializedGraphData,
+    graphTriples
+  }
+}

--- a/src/composables/shapedata.js
+++ b/src/composables/shapedata.js
@@ -18,7 +18,7 @@ export function useShapeData(shapes_graph_url) {
 	var nodeShapes = ref({});
 	var propertyGroups = ref({});
 	var nodeShapeNamesArray = ref([]);
-	var prefixes = reactive({});
+	var shapePrefixes = reactive({});
 	var prefixArray = ref([]);
 	var prefixes_ready = ref(false);
 	var nodeShapeIRIs = ref(null);
@@ -42,7 +42,7 @@ export function useShapeData(shapes_graph_url) {
 		.then(quadStream => {
 			// Load shape prefixes
 			quadStream.on('prefix', (prefix, ns) => {
-				prefixes[prefix] = ns.value;
+				shapePrefixes[prefix] = ns.value;
 				prefixArray.value.push(ns.value)
                 console.log(`prefix: ${prefix} ${ns.value}`)
 			}).on('end', () => {
@@ -118,7 +118,7 @@ export function useShapeData(shapes_graph_url) {
         nodeShapes,
         propertyGroups,
         nodeShapeNamesArray,
-        prefixes,
+        shapePrefixes,
         prefixArray,
         prefixes_ready,
         nodeShapeIRIs,

--- a/src/modules/io.js
+++ b/src/modules/io.js
@@ -11,8 +11,19 @@
 import formats from '@rdfjs/formats-common'
 import fetch from '@rdfjs/fetch-lite'
 
-export async function readRDF(file_url) {
-    const res = await fetch(file_url, { formats })
+export async function readRDF(file_url, headers) {
+    var res = null
+    if (headers) {
+        res = await fetch(file_url,
+            {
+                formats, 
+                headers: headers
+            }
+        )
+    } else {
+        res = await fetch(file_url,{formats })
+    }
+
     const quadStream = await res.quadStream()
     // quadStream.on('error', err => console.error(err))
     return quadStream

--- a/src/modules/namespaces.js
+++ b/src/modules/namespaces.js
@@ -7,3 +7,5 @@ export const DASH = rdf.namespace('http://datashapes.org/dash#');
 export const RDFS = rdf.namespace('http://www.w3.org/2000/01/rdf-schema#');
 export const XSD = rdf.namespace('http://www.w3.org/2001/XMLSchema#');
 export const DLDIST = rdf.namespace('https://concepts.datalad.org/s/distribution/unreleased/');
+export const DLTHING = rdf.namespace('https://concepts.datalad.org/s/thing/unreleased/');
+export const DLCO = rdf.namespace('https://concepts.datalad.org/');

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -1,13 +1,25 @@
 export function toCURIE(IRI, prefixes) {
-    for (const [curie, iri] of Object.entries(prefixes)) {
-        if (IRI.indexOf(iri) >= 0) {
-          var parts = IRI.split('/')
-          return curie + ':' + parts[parts.length - 1]
-        }
+  // prefixes is an object with prefix as keys and the resolved prexif IRI as the value
+  const longToShort = Object.values(prefixes).sort((a, b) => b.length - a.length);
+  for (const iri of longToShort) {
+    if (IRI.indexOf(iri) >= 0) {
+      const prefix = objectFlip(prefixes)[iri]
+      const property = IRI.substring(iri.length)
+      return prefix + ':' + property
     }
+  }
 }
 
 export function orderArrayOfObjects(array, key) {
   // Returns an array of objects ordered by the value of a specific key 
   return array.sort((a,b) => a[key] - b[key])
+}
+
+
+function objectFlip(obj) {
+  // Flip the keys and values of an object
+  return Object.keys(obj).reduce((ret, key) => {
+    ret[obj[key]] = key;
+    return ret;
+  }, {});
 }


### PR DESCRIPTION
This commit contains work-in-progress changes across many files. The main changes include:
- introduce a new composable 'graphdata.js' responsible for managing the graph dataset which is currently loaded on app startup and then made available to all components
- use rdf.dataset as the graph database, with accompanying functionality
- load the RDF-ified penguin dataset from a ttl file as the starting content of the dataset
- use rdf.grapois for graph traversal; this still needs much exploration. The main current use case is to find a particular subset of nodes that need to form part of a list for selection inside a InstanceSelector component, based on the sh:Class of the property shape for which the instance selector is rendered. For example, in a 'Distribution' form, when the instance selector for 'Authors' is rendered, it should contain all existing 'Person's in the database that the user might want to select from. This proved challenging with the grapois result of e.g. finding all triple subjects that reference a specific object via a specific predicate depending on how exactly the predicate and object are provided, e.g. as literals with datatype, or as URIs. This needs improved code to make the outcomes robust to changes in how triples exist within the database.
- fix a bug in the 'toCURIE' function that previously returned incorrect prefixes for a curie