### PR TITLE
remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,7 @@
         "buffer": "^6.0.3",
         "cytoscape": "^3.30.3",
         "rdf-ext": "^2.5.1",
-        "rdf-object": "^2.0.0",
         "roboto-fontface": "*",
-        "stream-browserify": "^3.0.0",
         "util": "^0.12.5",
         "uuid": "^10.0.0",
         "vue": "^3.4.0",
@@ -26,12 +24,10 @@
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.0.4",
-        "readable-stream": "github:WasabiThumb/readable-stream#bug/vite-esm",
         "sass": "^1.71.1",
         "unplugin-fonts": "^1.1.1",
         "unplugin-vue-components": "^0.26.0",
         "vite": "^5.1.5",
-        "vite-plugin-node-polyfills": "^0.22.0",
         "vite-plugin-vuetify": "^2.0.3",
         "vitepress": "^1.3.4"
       }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "buffer": "^6.0.3",
     "cytoscape": "^3.30.3",
     "rdf-ext": "^2.5.1",
-    "rdf-object": "^2.0.0",
     "roboto-fontface": "*",
-    "stream-browserify": "^3.0.0",
     "util": "^0.12.5",
     "uuid": "^10.0.0",
     "vue": "^3.4.0",
@@ -28,12 +26,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
-    "readable-stream": "github:WasabiThumb/readable-stream#bug/vite-esm",
     "sass": "^1.71.1",
     "unplugin-fonts": "^1.1.1",
     "unplugin-vue-components": "^0.26.0",
     "vite": "^5.1.5",
-    "vite-plugin-node-polyfills": "^0.22.0",
     "vite-plugin-vuetify": "^2.0.3",
     "vitepress": "^1.3.4"
   }

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,10 +8,6 @@ import ViteFonts from 'unplugin-fonts/vite'
 import { defineConfig } from 'vite'
 import { fileURLToPath, URL } from 'node:url'
 
-// Polyfill stuff
-import { nodePolyfills } from 'vite-plugin-node-polyfills'
-import path from 'path';
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -29,7 +25,6 @@ export default defineConfig({
         }],
       },
     }),
-    nodePolyfills(),
   ],
   define: {
     'process.env': {}, 
@@ -37,7 +32,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
-      'readable-stream': path.resolve(__dirname, 'node_modules/readable-stream'),
     },
     extensions: [
       '.js',
@@ -49,15 +43,7 @@ export default defineConfig({
       '.vue',
     ],
   },
-  optimizeDeps: {
-    include: ['rdf-object', 'readable-stream'],
-  },
   build: {
-    rollupOptions: {
-      plugins: [
-        nodePolyfills(),
-      ]
-    }
   },
   server: {
     port: 3000,


### PR DESCRIPTION
Remove unused dependencies, specifically rdf-object and all polyfill and rollup related dependencies that were added because of it.

This is to address the rollup build issue: https://github.com/psychoinformatics-de/shacl-vue/actions/runs/11930452565/job/33251263162#step:5:43