### PR TITLE
Fix infinite loop, and more

### DIFF
--- a/src/components/FormEditor.vue
+++ b/src/components/FormEditor.vue
@@ -249,7 +249,7 @@
 <style scoped>
     .scaled-sheet {
         transform: scale(0.9);
-        transform-origin: top right;
+        /* transform-origin: top right; */
     }
     .quote-description {
       border-left: 3px solid rgb(154, 153, 153);

--- a/src/components/NodeShapeEditor.vue
+++ b/src/components/NodeShapeEditor.vue
@@ -24,7 +24,7 @@
         </v-card>
     </span>
     <span v-else>
-        <span v-for="group in orderArrayOfObjects(Object.values(usedPropertyGroups), SHACL.order.value) ">
+        <span v-for="group in orderArrayOfObjects([...Object.values(usedPropertyGroups)], SHACL.order.value) ">
             <span v-if="group['own_properties'].length">
                 <h3>{{ group[RDFS.label.value] }}</h3>
                 <p><em>{{ group[RDFS.comment.value] }}</em></p>
@@ -40,7 +40,7 @@
 
 
 <script setup>
-    import { ref, onBeforeUpdate, onBeforeMount, onBeforeUnmount, onMounted, computed, inject} from 'vue'
+    import { ref, onBeforeUpdate, onBeforeMount, onBeforeUnmount, onMounted, inject, shallowRef} from 'vue'
     import {SHACL, RDF, RDFS, DLTHING} from '../modules/namespaces'
     import { orderArrayOfObjects } from '../modules/utils';
 
@@ -76,7 +76,11 @@
     // Lifecycle methods //
     // ----------------- //
 
+    const usedPropertyGroups = shallowRef({});
+
     onMounted(() => {
+
+        usedPropertyGroups.value = computeUsedPropertyGroups();
         ready.value = true;
         console.log("NodeShapeEditor is MOUNTED")
     })
@@ -102,7 +106,10 @@
     // Computed properties //
     // ------------------- //
 
-    const usedPropertyGroups = computed(() => {
+    
+
+    function computeUsedPropertyGroups() {
+        console.log("usedPropertyGroups recomputed");
         // first get a list of all the sh:PropertyGroup instances 
         // that are provided for any property via sh:group
         var group_instances = shape_obj.properties.map(function(shape_prop) {
@@ -141,21 +148,21 @@
                 }
             }
         }
-        return used_prop_groups
-    });
+        return used_prop_groups;
+    }
 
     // --------- //
     // Functions //
     // --------- //
 
-    function orderGroups() {
-        // first get a list of all the sh:PropertyGroup instances 
-        // that are provided for any property via sh:group
-        var group_instances = shape_obj.properties.map(function(shape_prop) {
-            return shape_prop[SHACL.group.value];
-        });
-        // make list unique and remove falsy values
-        group_instances = [...new Set(group_instances)].filter( Boolean )
-    }
+    // function orderGroups() {
+    //     // first get a list of all the sh:PropertyGroup instances 
+    //     // that are provided for any property via sh:group
+    //     var group_instances = shape_obj.properties.map(function(shape_prop) {
+    //         return shape_prop[SHACL.group.value];
+    //     });
+    //     // make list unique and remove falsy values
+    //     group_instances = [...new Set(group_instances)].filter( Boolean )
+    // }
 
 </script>

--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -74,7 +74,7 @@
 
                             </v-col>
                             <v-col v-if="formOpen" cols="9">
-                                <v-expansion-panels variant="accordion" v-model="currentOpenForm">
+                                <v-expansion-panels variant="accordion" v-model="currentOpenForm" class="custompanels">
                                     <v-expansion-panel
                                         v-for="(f, i) in openForms"
                                         :key="f.shapeIRI + '-'+ f.nodeIDX + '-expansionpanel'"
@@ -82,7 +82,7 @@
                                         :disabled="f.disabled"
                                     >
                                         <v-expansion-panel-title> <h2><em>Editing: {{ toCURIE(f.shapeIRI, allPrefixes) }} </em></h2></v-expansion-panel-title>
-                                        <v-expansion-panel-text>
+                                        <v-expansion-panel-text density="compact">
                                             <FormEditor :key="f.shapeIRI + '-'+ f.nodeIDX + '-form-' + f.formType" :shape_iri="f.shapeIRI" :node_idx="f.nodeIDX"></FormEditor>
                                         </v-expansion-panel-text>
                                     </v-expansion-panel>
@@ -520,5 +520,15 @@
     }
     .opacity-column {
         opacity: 0.5; /* Set opacity value between 0 (fully transparent) and 1 (fully opaque) */
+    }
+    .custompanels {
+        border: 1px solid #ccc !important; /* Change to your preferred color */
+        box-shadow: none !important; /* Remove elevation */
+        border-radius: 8px; /* Optional: Adjust border rounding */
+    }
+    .custompanels .v-expansion-panel {
+        border-bottom: 1px solid #ddd !important; /* Adds a subtle divider between panels */
+        box-shadow: none !important;
+        border-radius: 8px; /* Optional: Adjust border rounding */
     }
 </style>

--- a/src/composables/classdata.js
+++ b/src/composables/classdata.js
@@ -19,15 +19,19 @@ export function useClassData(config) {
 
     async function getClassData(url) {
         var getURL
+        console.log("getURL for classes:")
         if (!url) {
             // If no url argument provided, check config
             // Config priority is:
             // - if the class_url is provided, use it and ignore use_default_classes
             // - if the class_url is NOT provided, use default if use_default_classes==true, else nothing
             if (config.value.class_url) {
-                if (config.value.class_url.indexOf('http')) {
+                console.log("- specified via config")
+                if (config.value.class_url.indexOf('http') >= 0) {
+                    console.log("- contains http")
                     getURL = config.value.class_url
                 } else {
+                    console.log("- does not contain http")
                     getURL = `${basePath}${config.value.class_url}`;
                 }
             } else {
@@ -41,6 +45,7 @@ export function useClassData(config) {
         } else {
             getURL = url
         }
+        console.log(getURL)
 
         // console.log(`class url is: ${getURL}`)
         readRDF(getURL)

--- a/src/composables/graphdata.js
+++ b/src/composables/graphdata.js
@@ -33,7 +33,7 @@ export function useGraphData(config) {
       // - if the data_url is provided, use it and ignore use_default_data
       // - if the data_url is NOT provided, use default if use_default_data==true, else nothing
       if (config.value.data_url) {
-        if (config.value.data_url.indexOf('http')) {
+        if (config.value.data_url.indexOf('http')>=0) {
           getURL = config.value.data_url
         } else {
           getURL = `${basePath}${config.value.data_url}`;

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -67,7 +67,7 @@ export function nameOrCURIE(shape, prefixes) {
 
 export function orderArrayOfObjects(array, key) {
   // Returns an array of objects ordered by the value of a specific key 
-  return array.sort((a,b) => a[key] - b[key])
+  return [...array].sort((a,b) => a[key] - b[key])
 }
 
 


### PR DESCRIPTION
This PR:

- (touch wood) fixes the longstanding issue where an infinite loop caused the application to hang when the user selected 'Add new item' from the autocomplete dropdown of an `InstancesSelectEditor` component. The actual issue occurred in the `NodeShapeEditor` where the computed property `usedPropertyGroups` caused the component's `onBeforeUpdate` hook to be called infinitely. This property was changes to a shallow ref and it's value is now set once in the `onMounted` hook. This resulted locally in the 'maximum updates exceeded' error disappearing. The next test is to see if this persists when the site is built and served remotely. In addition, small changes were made to an array ordering function to rather order a copy than an array in-place (which 'order') does).
- fixes a relative URL issue with the class hierarchy URL
- Puts rendered forms in the hoirizontal center of the expansion panels