### PR TITLE
Service integration and more

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -15,5 +15,12 @@
         }
     },
     "id_iri": "https://concepts.datalad.org/s/things/v1/id",
-    "show_shapes_wo_id": false
+    "show_shapes_wo_id": false,
+    "use_service": false,
+    "service_base_url": "",
+    "service_endpoints":  {
+        "post-record": "record/{name}&format=ttl",
+        "get-record": "record?id={curie}&format=ttl",
+        "get-records": "records/{name}?format=ttl"
+    }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,11 +43,19 @@
 
 
 <script setup>
-  import { ref } from 'vue'
+  import { ref, provide } from 'vue'
   const explore = ref(true)
   function startExploring() {
       explore.value = true;
   }
+  const canSubmit = ref(true)
+  const submitButtonPressed = ref(false)
+  function submitFn() {
+      submitButtonPressed.value = true
+  }
+  provide('submitButtonPressed', submitButtonPressed)
+  provide('submitFn', submitFn)
+  provide('canSubmit', canSubmit)
 
 </script>
 

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,29 +1,55 @@
 <template>
-  <v-app-bar :elevation="1" rounded>
-    <template v-slot:prepend>
-      <v-img
-        :width="36"
-        cover
-        src="../assets/shacl_vue.svg"
-        style="margin-left: 10px;"
-      ></v-img>
-    </template>
+    <v-app-bar :elevation="1" rounded>
+        <template v-slot:prepend>
+            <v-img
+                :width="36"
+                cover
+                src="../assets/shacl_vue.svg"
+                style="margin-left: 10px;"
+            ></v-img>
+        </template>
 
-    <v-app-bar-title> 
-      <code style="font-size: 1em;">shacl-vue</code>
-    </v-app-bar-title>
+        <v-app-bar-title> 
+            <code style="font-size: 1em;">shacl-vue</code>
+        </v-app-bar-title>
 
-    <template v-slot:append>
-      <v-btn 
-        icon="mdi-text-box"
-        href="https://psychoinformatics-de.github.io/shacl-vue/docs/"
-        target="_blank"
-      ></v-btn>
-      <v-btn 
-        icon="mdi-github"
-        href="https://github.com/psychoinformatics-de/shacl-vue"
-        target="_blank"
-      ></v-btn>
-    </template>
-  </v-app-bar>
+        <template v-slot:append>
+            
+            <v-tooltip text="Submit" location="bottom">
+                <template v-slot:activator="{ props }">
+                    <v-btn 
+                    icon="mdi-cloud-upload"
+                    @click="submitFn()"
+                    v-bind="props"
+                    :disabled="!canSubmit"
+                    ></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Documentation" location="bottom">
+                <template v-slot:activator="{ props }">
+                    <v-btn 
+                    icon="mdi-text-box"
+                    href="https://psychoinformatics-de.github.io/shacl-vue/docs/"
+                    target="_blank"
+                    v-bind="props"
+                    ></v-btn>
+                </template>
+            </v-tooltip>
+            <v-tooltip text="Source code" location="bottom">
+                <template v-slot:activator="{ props }">
+                    <v-btn 
+                    icon="mdi-github"
+                    href="https://github.com/psychoinformatics-de/shacl-vue"
+                    target="_blank"
+                    v-bind="props"
+                    ></v-btn>
+                </template>
+            </v-tooltip>
+        </template>
+    </v-app-bar>
 </template>
+<script setup>
+    import { inject} from 'vue'
+    const submitFn = inject('submitFn')
+    const canSubmit = inject('canSubmit')
+</script>

--- a/src/components/FormEditor.vue
+++ b/src/components/FormEditor.vue
@@ -249,7 +249,7 @@
 <style scoped>
     .scaled-sheet {
         transform: scale(0.9);
-        /* transform-origin: top right; */
+        transform-origin: top;
     }
     .quote-description {
       border-left: 3px solid rgb(154, 153, 153);

--- a/src/components/MainData.vue
+++ b/src/components/MainData.vue
@@ -19,7 +19,6 @@
                         <!-- BROWSE DATA -->
                         <v-tabs-window-item :key="1" :value="1">
                             <v-sheet d-flex d-flex-grow class="pa-4 ml-2" border rounded style="width: 100%;">
-                                <!-- <v-btn text="Download samples.tsv" @click="serializeNodesToTSV"></v-btn> -->
                                 <v-select v-model="selectedFormItem" v-if="prefixes_ready" :items="nodeShapeNamesArray" item-title="name" label="Select" density="compact" style="width: 100%;">
                                     <template v-slot:item="{ props, item }">
                                     <v-list-item v-bind="props" :title="toCURIE(nodeShapeNames[item.raw], shapePrefixes)" @click="selectIRI(nodeShapeNames[item.raw])"></v-list-item>
@@ -155,7 +154,6 @@
     const formData = inject('formData');
     const classData = inject('classData');
     const serializedGraphData = inject('serializedGraphData');
-    const serializeNodesToTSV = inject('serializeNodesToTSV')
     const public_url = ref('')
     const upload_url = ref(null)
     const datatab = ref(1)

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -12,16 +12,18 @@
             <span v-if="formData[localNodeUid][localNodeIdx]">
                 <v-row no-gutters v-for="(triple, triple_idx) in formData[localNodeUid][localNodeIdx][my_uid]" :key="localNodeUid + '-' + my_uid + '-' + triple_idx">
                     <v-col cols="9">
-                        <component
-                            v-model="formData[localNodeUid][localNodeIdx][my_uid][triple_idx]"
-                            :is="matchedComponent"
-                            :property_shape="localPropertyShape"
-                            :node_uid="localNodeUid"
-                            :node_idx="localNodeIdx"
-                            :triple_uid="my_uid"
-                            :triple_idx="triple_idx"
-                            >
-                        </component>
+                        <Suspense>
+                            <component
+                                v-model="formData[localNodeUid][localNodeIdx][my_uid][triple_idx]"
+                                :is="matchedComponent"
+                                :property_shape="localPropertyShape"
+                                :node_uid="localNodeUid"
+                                :node_idx="localNodeIdx"
+                                :triple_uid="my_uid"
+                                :triple_idx="triple_idx"
+                                >
+                            </component>
+                        </Suspense>
                     </v-col>
                     <v-col>
                             &nbsp;

--- a/src/components/SubmitComp.vue
+++ b/src/components/SubmitComp.vue
@@ -1,0 +1,65 @@
+<template>
+    <v-card>
+        <v-card-title>Submit metadata</v-card-title>
+        <v-card-text>
+            <span v-if="tokenExists">
+                Are you sure you want to continue?
+            </span>
+            <span v-else>
+                Please add a valid token before submitting your changes.
+                <v-form>
+                    <v-text-field
+                        v-model="tokenval"
+                        label="Token"
+                        :rules="rules"
+                    ></v-text-field>
+                </v-form>
+            </span>
+        </v-card-text>
+        <v-card-actions>
+            <v-btn @click="cancelSubmit()"><v-icon>mdi-cancel</v-icon> Cancel</v-btn>
+            <v-btn type="submit" @click="submit"><v-icon>mdi-check-circle-outline</v-icon> Submit</v-btn>
+        </v-card-actions>
+    </v-card>
+</template>
+
+<script setup>
+    import { ref, onBeforeMount, inject} from 'vue';
+    import { useToken } from '@/composables/tokens'
+    import { useFormData } from '@/composables/formdata'
+
+    const props = defineProps({
+        dialog: Boolean
+    })
+
+    const { token, setToken, clearToken } = useToken()
+    const {submitFormData} = useFormData()
+    const submitButtonPressed = inject('submitButtonPressed')
+    const submitDialog = inject('submitDialog')
+    const tokenExists = ref(false)
+
+    const rules = [
+        value => {
+            if (value) return true
+            return 'Please enter a token to submit your edits'
+        },
+    ]
+
+    function submit() {
+        if (!tokenExists.value) {
+            setToken(tokenval.value)
+        }
+        submitFormData()
+    }
+
+    function cancelSubmit() {
+        submitButtonPressed.value = false
+        submitDialog.value = false
+    }
+
+    onBeforeMount(()=>{
+        if (token.value) {
+            tokenExists.value = true
+        }
+    })
+</script>

--- a/src/components/URIEditor.vue
+++ b/src/components/URIEditor.vue
@@ -145,6 +145,7 @@
             } else {
                 URIprefix = null;
                 URIpath = '';
+                enterCURIE.value = false
             }
         }
         return {

--- a/src/composables/formdata.js
+++ b/src/composables/formdata.js
@@ -19,296 +19,296 @@ import formatsPretty from '@rdfjs/formats/pretty.js'
 
 export function useFormData() {
 
-  const formData = reactive({})
-  const rdfPretty = rdf.clone()
-  rdfPretty.formats.import(formatsPretty)  
-  
-  function add_empty_node(nodeshape_iri, node_iri) {
-    // if the node shape IRI does not exist in the formData lookup object yet, add it
-    // if the node shape IRI already exists in the formData lookup object:
-    // - if the specific iri does not exists, add it
-    // - if the specific iri exists do nothing
-    if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
-      // The added value is an object; to allow adding multiple of the same node type,
-      // unique subject IRIs (from named or blank nodes) will be the unique keys of the object
-      formData[nodeshape_iri] = reactive({})
-    }
-    if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
-      // The added value is an object with keys == predicates and values being arrays
-      // that can take multiple object values
-      // TODO: this needs to be trialed because unsure whether this or alternative is more suitable
-      // alternative could be having an object with both keys and values being the object, or
-      // keys being numeric and sequential, and values being object values
-      formData[nodeshape_iri][node_iri] = reactive({})
-    } 
-  }
+    const formData = reactive({})
+    const rdfPretty = rdf.clone()
+    rdfPretty.formats.import(formatsPretty)  
 
-
-  function remove_current_node(nodeshape_iri, node_iri) {
-    // Error: if the node shape iri does not exist in the lookup object
-    if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
-      console.error(`Trying to delete a node of a shape that does not exist in form data:\n${nodeshape_iri}`)
-    }
-    // Error: if the node iri does not exist in the lookup object
-    else if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
-      console.error(`Trying to delete a node that does not exist in form data:\n${nodeshape_iri} - ${node_iri}`)
-    }
-    // remove node instance at provided iri
-    // if node object is empty after instance removal, remove node key as well
-    else {
-      delete formData[nodeshape_iri][node_iri]
-      if ( isEmptyObject(formData[nodeshape_iri])) { delete formData[nodeshape_iri] }
-    }
-  }
-
-
-  function clear_current_node(nodeshape_iri, node_iri) {
-    // Error: if the node key does not exist in the lookup object
-    if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
-      console.error(`Trying to clear a node of a shape that does not exist in form data:\n${nodeshape_iri}`)
-    }
-    // Error: if the node idx does not exist in the lookup object
-    else if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
-      console.error(`Trying to clear a node that does not exist in form data:\n${nodeshape_iri} - ${node_iri}`)
-    }
-    // clear node instance at provided index
-    else {
-      objectKeysToNull(formData[nodeshape_iri][node_iri])
-    }
-  }
-
-
-  function add_empty_triple(nodeshape_iri, node_iri, triple_uid) {
-    // console.log(`Adding empty triple:\nnodeshape_iri: ${nodeshape_iri}\nnode_iri: ${node_iri}\ntriple_uid: ${triple_uid}`)
-    // if the node shape+iri exist and the triple uid (predicate) does not exist, add it
-    // if the node shape+iri exist and the triple uid already exists, add empty value to array
-    // if the node shape+iri do not exist, print console error because this should not be possible
-    if (Object.keys(formData).indexOf(nodeshape_iri) >= 0 && Object.keys(formData[nodeshape_iri]).indexOf(node_iri) >= 0) {
-      // Current node being edited at IRI
-      if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(triple_uid) < 0) {
-        formData[nodeshape_iri][node_iri][triple_uid] = reactive([null])
-      } else {
-        // 
-      }
-    } else {
-      console.error(`Node shape and/or node IRI not in formData yet:\n${nodeshape_iri} - ${node_iri}\nCannot add triple to non-existing node.`)
-    }
-  }
-
-
-  function add_empty_triple_manual(nodeshape_iri, node_iri, triple_uid) {
-    formData[nodeshape_iri][node_iri][triple_uid].push(null)
-  }
-
-
-  
-
-
-  function remove_triple(nodeshape_iri, node_iri, triple_uid, triple_idx) {
-    if (Object.keys(formData).indexOf(nodeshape_iri) >= 0 && Object.keys(formData[nodeshape_iri]).indexOf(node_iri) >= 0) {
-      // Current node being edited at index
-      if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(triple_uid) < 0) {
-        console.error(`Triple UID ${triple_uid} not in specific node IRI instance in formData:\n${nodeshape_iri} - ${node_iri}\nCannot remove non-existing triple.`)
-      } else {
-        formData[nodeshape_iri][node_iri][triple_uid].splice(triple_idx, 1)
-      }
-    } else {
-      console.error(`Node shape and/or node IRI not in formData yet:\n${nodeshape_iri} - ${node_iri}\nCannot remove triple from non-existing node.`)
-    }
-  }
-
-
-  function save_node(nodeshape_iri, node_iri, nodeShapes, graphData, editMode, id_iri) {
-    // Check if the node exists beforehand
-    console.log(`Saving node of shape: ${nodeshape_iri}`)
-    var changeNodeIdx = false
-    var rereferenceTriples = false
-    var subject_iri = null
-    if (formData[nodeshape_iri]) {
-      // console.log("Node has entry in formData")
-      // console.log(`Current node value: ${formData[nodeshape_iri].at(-1)}`)
-
-      // If we are in edit more, the first step is to delete existing quads from graphData
-      if (editMode) {
-        console.log("saving while in edit mode -> delete preexisting quads from dataset")
-        graphData.deleteMatches(rdf.namedNode(node_iri), null, null, null)
-      }
-
-      var shape = nodeShapes[nodeshape_iri]
-      // console.log(`Node shape: ${shape}`)
-      var properties = shape.properties
-      // Subject should either be a named node or blank node
-      // - named node if any of the properties is an ID (as defined by some IRI as constant or from config, see declarations above)
-      // - blank node if no ID found
-      var subject
-      if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(id_iri) >= 0) {
-        // console.log(`\t- node instance has ID field: ${formData[nodeshape_iri][node_iri][id_iri][0]}`)
-        subject_iri = formData[nodeshape_iri][node_iri][id_iri][0]
-        subject = rdf.namedNode(subject_iri)
-        changeNodeIdx = true
-      } else {
-        // console.log(`\t- node instance DOES NOT have ID field`)
-        subject = rdf.blankNode(node_iri) // node_iri is created with crypto.randomUUID(), so it is unique
-      }
-      // Add the first quad, specifying rdf-type of the node
-      let firstQuad = rdf.quad(subject, rdf.namedNode(RDF.type.value), rdf.namedNode(nodeshape_iri))
-      console.log(`Adding quad to data graph:\n${firstQuad.toString()}`)
-      graphData.add(firstQuad)
-      // Now: loop through all keys, i.e. properties of shape, i.e. triple predicates
-      for (var pred of Object.keys(formData[nodeshape_iri][node_iri])) {
-        // console.log(`\t- processing predicate: ${pred}`)
-        // Only process entered values
-        if (Array.isArray(formData[nodeshape_iri][node_iri][pred]) &&
-          formData[nodeshape_iri][node_iri][pred].length == 1 &&
-          formData[nodeshape_iri][node_iri][pred][0] === null) {
-          // console.log("Node predicate has no value, skipping")
-          continue;
+    function add_empty_node(nodeshape_iri, node_iri) {
+        // if the node shape IRI does not exist in the formData lookup object yet, add it
+        // if the node shape IRI already exists in the formData lookup object:
+        // - if the specific iri does not exists, add it
+        // - if the specific iri exists do nothing
+        if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
+            // The added value is an object; to allow adding multiple of the same node type,
+            // unique subject IRIs (from named or blank nodes) will be the unique keys of the object
+            formData[nodeshape_iri] = reactive({})
         }
-        // Don't add ID quad:
-        if (pred == id_iri) {
-          continue;
-        }
-        var predicate = rdf.namedNode(pred)
-        // Find associated property shape, for information about nodekind
-        var property_shape = properties.find((prop) => prop[SHACL.path.value] == pred)
-        var nodeFunc = null
-        var dt = null
-        if (property_shape.hasOwnProperty(SHACL.nodeKind.value)) {
-          // options = sh:BlankNode, sh:IRI, sh:Literal, sh:BlankNodeOrIRI, sh:BlankNodeOrLiteral, sh:IRIOrLiteral
-          // sh:nodeKind == sh:Literal
-          if (property_shape[SHACL.nodeKind.value] == SHACL.Literal.value) {
-            nodeFunc = rdf.literal
-            // sh:datatype exists
-            if (property_shape.hasOwnProperty(SHACL.datatype.value)) {
-              dt = property_shape[SHACL.datatype.value]
-            }
-          } else if ([SHACL.IRI.value, SHACL.BlankNodeOrIRI.value].includes(property_shape[SHACL.nodeKind.value])) {
-            nodeFunc = rdf.namedNode
-          } else {
-            console.error(`\t- NodeKind not supported: ${property_shape[SHACL.nodeKind.value]}\n\t\tAdding triple with literal object to graphData`)
-            nodeFunc = rdf.literal
-          }
-        } else if (property_shape.hasOwnProperty(SHACL.in.value)) {
-          // This is a temporary workaround; should definitely not be permanent
-          // Assume Literal nodekind for any arrays
-          nodeFunc = rdf.literal
+        if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
+            // The added value is an object with keys == predicates and values being arrays
+            // that can take multiple object values
+            // TODO: this needs to be trialed because unsure whether this or alternative is more suitable
+            // alternative could be having an object with both keys and values being the object, or
+            // keys being numeric and sequential, and values being object values
+            formData[nodeshape_iri][node_iri] = reactive({})
+        } 
+    }
 
+
+    function remove_current_node(nodeshape_iri, node_iri) {
+        // Error: if the node shape iri does not exist in the lookup object
+        if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
+            console.error(`Trying to delete a node of a shape that does not exist in form data:\n${nodeshape_iri}`)
         }
+        // Error: if the node iri does not exist in the lookup object
+        else if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
+            console.error(`Trying to delete a node that does not exist in form data:\n${nodeshape_iri} - ${node_iri}`)
+        }
+        // remove node instance at provided iri
+        // if node object is empty after instance removal, remove node key as well
         else {
-          console.error(`\t- NodeKind not found for property shape: ${pred}\n\tCannot add triple to graphData. Here's the full property shape:`)
-          console.error(property_shape)
+            delete formData[nodeshape_iri][node_iri]
+            if ( isEmptyObject(formData[nodeshape_iri])) { delete formData[nodeshape_iri] }
         }
+    }
 
-        // Loop through all elements of the array with triple objects
-        for (var obj of formData[nodeshape_iri][node_iri][pred]) {
-          let triple_object
-          if (dt) {
-            triple_object = nodeFunc(String(obj), dt)
-          } else {
-            triple_object = nodeFunc(obj)
-          }
-          let quad = rdf.quad(subject, predicate, triple_object)
-          // console.log(`Adding quad to data graph:\n${quad.toString()}`)
-          graphData.add(quad)
+
+    function clear_current_node(nodeshape_iri, node_iri) {
+        // Error: if the node key does not exist in the lookup object
+        if (Object.keys(formData).indexOf(nodeshape_iri) < 0) {
+            console.error(`Trying to clear a node of a shape that does not exist in form data:\n${nodeshape_iri}`)
         }
-      }
-      // If this was in editmode and the node IRI has been altered,
-      // i.e. node_iri is not the same as the new value in formData,
-      // then we need to RE-reference existing triples in the graph that has the current node_iri as object.
-      // This is only necessary for namedNodes where the IRI changed. The process is:
-      // - only do the following if the node is a namedNode and if the IRI changed during editing
-      // - find all triples with the node IRI as object -> oldTriples
-      // - for each triple in oldTriples: create a new one with same subject and predicate
-      //   and with new IRI as object, then delete the old triple
-      if (editMode && subject_iri !== null && subject_iri !== node_iri) {
-        var objectQuads = getObjectTriples(graphData, rdf.namedNode(node_iri))
-        objectQuads.forEach((quad) => {
-          let new_quad = rdf.quad(quad.subject, quad.predicate, subject)
-          graphData.delete(quad)
-          graphData.add(new_quad)
+        // Error: if the node idx does not exist in the lookup object
+        else if (Object.keys(formData[nodeshape_iri]).indexOf(node_iri) < 0) {
+            console.error(`Trying to clear a node that does not exist in form data:\n${nodeshape_iri} - ${node_iri}`)
+        }
+        // clear node instance at provided index
+        else {
+            objectKeysToNull(formData[nodeshape_iri][node_iri])
+        }
+    }
+
+
+    function add_empty_triple(nodeshape_iri, node_iri, triple_uid) {
+        // console.log(`Adding empty triple:\nnodeshape_iri: ${nodeshape_iri}\nnode_iri: ${node_iri}\ntriple_uid: ${triple_uid}`)
+        // if the node shape+iri exist and the triple uid (predicate) does not exist, add it
+        // if the node shape+iri exist and the triple uid already exists, add empty value to array
+        // if the node shape+iri do not exist, print console error because this should not be possible
+        if (Object.keys(formData).indexOf(nodeshape_iri) >= 0 && Object.keys(formData[nodeshape_iri]).indexOf(node_iri) >= 0) {
+            // Current node being edited at IRI
+            if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(triple_uid) < 0) {
+                formData[nodeshape_iri][node_iri][triple_uid] = reactive([null])
+            } else {
+                formData[nodeshape_iri][node_iri][triple_uid].push(null)
+            }
+        } else {
+            console.error(`Node shape and/or node IRI not in formData yet:\n${nodeshape_iri} - ${node_iri}\nCannot add triple to non-existing node.`)
+        }
+    }
+
+
+    function add_empty_triple_manual(nodeshape_iri, node_iri, triple_uid) {
+        formData[nodeshape_iri][node_iri][triple_uid].push(null)
+    }
+
+
+
+
+
+    function remove_triple(nodeshape_iri, node_iri, triple_uid, triple_idx) {
+        if (Object.keys(formData).indexOf(nodeshape_iri) >= 0 && Object.keys(formData[nodeshape_iri]).indexOf(node_iri) >= 0) {
+            // Current node being edited at index
+            if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(triple_uid) < 0) {
+                console.error(`Triple UID ${triple_uid} not in specific node IRI instance in formData:\n${nodeshape_iri} - ${node_iri}\nCannot remove non-existing triple.`)
+            } else {
+                formData[nodeshape_iri][node_iri][triple_uid].splice(triple_idx, 1)
+            }
+        } else {
+            console.error(`Node shape and/or node IRI not in formData yet:\n${nodeshape_iri} - ${node_iri}\nCannot remove triple from non-existing node.`)
+        }
+    }
+
+
+    function save_node(nodeshape_iri, node_iri, nodeShapes, graphData, editMode, id_iri) {
+        // Check if the node exists beforehand
+        console.log(`Saving node of shape: ${nodeshape_iri}`)
+        var changeNodeIdx = false
+        var rereferenceTriples = false
+        var subject_iri = null
+        if (formData[nodeshape_iri]) {
+            // console.log("Node has entry in formData")
+            // console.log(`Current node value: ${formData[nodeshape_iri].at(-1)}`)
+
+            // If we are in edit more, the first step is to delete existing quads from graphData
+            if (editMode) {
+                console.log("saving while in edit mode -> delete preexisting quads from dataset")
+                graphData.deleteMatches(rdf.namedNode(node_iri), null, null, null)
+            }
+
+            var shape = nodeShapes[nodeshape_iri]
+            // console.log(`Node shape: ${shape}`)
+            var properties = shape.properties
+            // Subject should either be a named node or blank node
+            // - named node if any of the properties is an ID (as defined by some IRI as constant or from config, see declarations above)
+            // - blank node if no ID found
+            var subject
+            if (Object.keys(formData[nodeshape_iri][node_iri]).indexOf(id_iri) >= 0) {
+                // console.log(`\t- node instance has ID field: ${formData[nodeshape_iri][node_iri][id_iri][0]}`)
+                subject_iri = formData[nodeshape_iri][node_iri][id_iri][0]
+                subject = rdf.namedNode(subject_iri)
+                changeNodeIdx = true
+            } else {
+                // console.log(`\t- node instance DOES NOT have ID field`)
+                subject = rdf.blankNode(node_iri) // node_iri is created with crypto.randomUUID(), so it is unique
+            }
+            // Add the first quad, specifying rdf-type of the node
+            let firstQuad = rdf.quad(subject, rdf.namedNode(RDF.type.value), rdf.namedNode(nodeshape_iri))
+            console.log(`Adding quad to data graph:\n${firstQuad.toString()}`)
+            graphData.add(firstQuad)
+            // Now: loop through all keys, i.e. properties of shape, i.e. triple predicates
+            for (var pred of Object.keys(formData[nodeshape_iri][node_iri])) {
+                // console.log(`\t- processing predicate: ${pred}`)
+                // Only process entered values
+                if (Array.isArray(formData[nodeshape_iri][node_iri][pred]) &&
+                    formData[nodeshape_iri][node_iri][pred].length == 1 &&
+                    formData[nodeshape_iri][node_iri][pred][0] === null) {
+                    // console.log("Node predicate has no value, skipping")
+                    continue;
+                }
+                // Don't add ID quad:
+                if (pred == id_iri) {
+                    continue;
+                }
+                var predicate = rdf.namedNode(pred)
+                // Find associated property shape, for information about nodekind
+                var property_shape = properties.find((prop) => prop[SHACL.path.value] == pred)
+                var nodeFunc = null
+                var dt = null
+                if (property_shape.hasOwnProperty(SHACL.nodeKind.value)) {
+                    // options = sh:BlankNode, sh:IRI, sh:Literal, sh:BlankNodeOrIRI, sh:BlankNodeOrLiteral, sh:IRIOrLiteral
+                    // sh:nodeKind == sh:Literal
+                    if (property_shape[SHACL.nodeKind.value] == SHACL.Literal.value) {
+                        nodeFunc = rdf.literal
+                        // sh:datatype exists
+                        if (property_shape.hasOwnProperty(SHACL.datatype.value)) {
+                            dt = property_shape[SHACL.datatype.value]
+                        }
+                    } else if ([SHACL.IRI.value, SHACL.BlankNodeOrIRI.value].includes(property_shape[SHACL.nodeKind.value])) {
+                        nodeFunc = rdf.namedNode
+                    } else {
+                        console.error(`\t- NodeKind not supported: ${property_shape[SHACL.nodeKind.value]}\n\t\tAdding triple with literal object to graphData`)
+                        nodeFunc = rdf.literal
+                    }
+                } else if (property_shape.hasOwnProperty(SHACL.in.value)) {
+                    // This is a temporary workaround; should definitely not be permanent
+                    // Assume Literal nodekind for any arrays
+                    nodeFunc = rdf.literal
+
+                }
+                else {
+                    console.error(`\t- NodeKind not found for property shape: ${pred}\n\tCannot add triple to graphData. Here's the full property shape:`)
+                    console.error(property_shape)
+                }
+
+                // Loop through all elements of the array with triple objects
+                for (var obj of formData[nodeshape_iri][node_iri][pred]) {
+                    let triple_object
+                    if (dt) {
+                        triple_object = nodeFunc(String(obj), dt)
+                    } else {
+                        triple_object = nodeFunc(obj)
+                    }
+                    let quad = rdf.quad(subject, predicate, triple_object)
+                    // console.log(`Adding quad to data graph:\n${quad.toString()}`)
+                    graphData.add(quad)
+                }
+            }
+            // If this was in editmode and the node IRI has been altered,
+            // i.e. node_iri is not the same as the new value in formData,
+            // then we need to RE-reference existing triples in the graph that has the current node_iri as object.
+            // This is only necessary for namedNodes where the IRI changed. The process is:
+            // - only do the following if the node is a namedNode and if the IRI changed during editing
+            // - find all triples with the node IRI as object -> oldTriples
+            // - for each triple in oldTriples: create a new one with same subject and predicate
+            //   and with new IRI as object, then delete the old triple
+            if (editMode && subject_iri !== null && subject_iri !== node_iri) {
+                var objectQuads = getObjectTriples(graphData, rdf.namedNode(node_iri))
+                objectQuads.forEach((quad) => {
+                    let new_quad = rdf.quad(quad.subject, quad.predicate, subject)
+                    graphData.delete(quad)
+                    graphData.add(new_quad)
+                });
+            }
+
+            // Change formdata node_iri to the actual id, if this was present:
+            if (changeNodeIdx && subject_iri !== node_iri) {
+                formData[nodeshape_iri][subject_iri] = reactive(structuredClone(toRaw(formData[nodeshape_iri][node_iri])))
+                delete formData[nodeshape_iri][node_iri]
+            }
+            // at the end, what to do with current data in formdata? delete node element?
+        } else {
+            console.error(`\t- Node ${nodeshape_iri} does not exist`)
+        }
+    }
+
+
+    function quadsToFormData(nodeshape_iri, subject_term, graphData, id_iri) {
+        // Subject term should be namedNode or blankNode
+        var node_iri = subject_term.value
+        add_empty_node(nodeshape_iri, node_iri)
+        // Get all triples with the term as subject, and add to formData
+        // NOTE: these triples added to formData are only the ones that exist in graphData
+        // i.e. only the values that the subject has been annotated with. The node shape
+        // defines all properties that the node could have, of which the actual existing
+        // properties are only a subset. This means that the `add_empty_triple` call below
+        // is not populating all possible empty properties for the node, such that the form
+        // can be edited in full. At the moment, this task is left to the `add_empty_triple`
+        // call that is done in `onMounted` of the `PropertyShapeEditor` component. It is
+        // to be determined whether this is the best way forward. But it works for now.
+        // TODO ^^
+
+        // Another TODO: the ID property of the node is not necessarily existing explicitly
+        // as a triple in the graph. Refer to the `save_node` function above, where the quad
+        // with the id_iri as predicate is not added to the graph when formData is saved.
+        // For the current `quadsToFormData` function, the reverse process is important
+        // to keep in mind, i.e. because the id_iri quad does not exist in the graph,
+        // the corresponding field in formData has to be set explicitly from the subject_term,
+        // because it won't be covered in the `quadArray.forEach` loop.
+        var quadArray = getSubjectTriples(graphData, subject_term)
+        var IdQuadExists = false
+        quadArray.forEach((quad) => {
+            var triple_uid = quad.predicate.value
+            if (triple_uid === id_iri) {
+                IdQuadExists = true
+            }
+            add_empty_triple(nodeshape_iri, node_iri, triple_uid)
+            var length = formData[nodeshape_iri][node_iri][triple_uid].length
+            formData[nodeshape_iri][node_iri][triple_uid][length-1] = quad.object.value
         });
-      }
-
-      // Change formdata node_iri to the actual id, if this was present:
-      if (changeNodeIdx && subject_iri !== node_iri) {
-        formData[nodeshape_iri][subject_iri] = reactive(structuredClone(toRaw(formData[nodeshape_iri][node_iri])))
-        delete formData[nodeshape_iri][node_iri]
-      }
-      // at the end, what to do with current data in formdata? delete node element?
-    } else {
-      console.error(`\t- Node ${nodeshape_iri} does not exist`)
+        // Here we deal with explicitly adding the id_iri quad, if necessary
+        if (subject_term.termType === "NamedNode"  && !IdQuadExists) {
+            add_empty_triple(nodeshape_iri, node_iri, id_iri)
+            var l = formData[nodeshape_iri][node_iri][id_iri].length
+            formData[nodeshape_iri][node_iri][id_iri][l-1] = node_iri
+        }
     }
-  }
 
 
-  function quadsToFormData(nodeshape_iri, subject_term, graphData, id_iri) {
-    // Subject term should be namedNode or blankNode
-    var node_iri = subject_term.value
-    add_empty_node(nodeshape_iri, node_iri)
-    // Get all triples with the term as subject, and add to formData
-    // NOTE: these triples added to formData are only the ones that exist in graphData
-    // i.e. only the values that the subject has been annotated with. The node shape
-    // defines all properties that the node could have, of which the actual existing
-    // properties are only a subset. This means that the `add_empty_triple` call below
-    // is not populating all possible empty properties for the node, such that the form
-    // can be edited in full. At the moment, this task is left to the `add_empty_triple`
-    // call that is done in `onMounted` of the `PropertyShapeEditor` component. It is
-    // to be determined whether this is the best way forward. But it works for now.
-    // TODO ^^
-
-    // Another TODO: the ID property of the node is not necessarily existing explicitly
-    // as a triple in the graph. Refer to the `save_node` function above, where the quad
-    // with the id_iri as predicate is not added to the graph when formData is saved.
-    // For the current `quadsToFormData` function, the reverse process is important
-    // to keep in mind, i.e. because the id_iri quad does not exist in the graph,
-    // the corresponding field in formData has to be set explicitly from the subject_term,
-    // because it won't be covered in the `quadArray.forEach` loop.
-    var quadArray = getSubjectTriples(graphData, subject_term)
-    var IdQuadExists = false
-    quadArray.forEach((quad) => {
-      var triple_uid = quad.predicate.value
-      if (triple_uid === id_iri) {
-        IdQuadExists = true
-      }
-      add_empty_triple(nodeshape_iri, node_iri, triple_uid)
-      var length = formData[nodeshape_iri][node_iri][triple_uid].length
-      formData[nodeshape_iri][node_iri][triple_uid][length-1] = quad.object.value
-    });
-    // Here we deal with explicitly adding the id_iri quad, if necessary
-    if (subject_term.termType === "NamedNode"  && !IdQuadExists) {
-      add_empty_triple(nodeshape_iri, node_iri, id_iri)
-      var l = formData[nodeshape_iri][node_iri][id_iri].length
-      formData[nodeshape_iri][node_iri][id_iri][l-1] = node_iri
+    function clearObjectKeys(obj) {
+        for (var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                delete obj[key];
+            }
+        }
     }
-  }
 
-
-  function clearObjectKeys(obj) {
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        delete obj[key];
-      }
+    function objectKeysToNull(obj) {
+        for (var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+                obj[key] = reactive([null])
+            }
+        }
     }
-  }
 
-  function objectKeysToNull(obj) {
-    for (var key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        obj[key] = reactive([null])
-      }
+    // expose managed state as return value
+    return {
+        formData,
+        add_empty_node,
+        remove_current_node,
+        clear_current_node,
+        add_empty_triple,
+        add_empty_triple_manual,
+        remove_triple,
+        save_node,
+        quadsToFormData,
     }
-  }
-
-  // expose managed state as return value
-  return {
-    formData,
-    add_empty_node,
-    remove_current_node,
-    clear_current_node,
-    add_empty_triple,
-    add_empty_triple_manual,
-    remove_triple,
-    save_node,
-    quadsToFormData,
-  }
 }

--- a/src/composables/graphdata.js
+++ b/src/composables/graphdata.js
@@ -4,192 +4,198 @@ import { readRDF } from '@/modules/io'
 import rdf from 'rdf-ext';
 import { SHACL , RDF} from '../modules/namespaces'
 import formatsPretty from '@rdfjs/formats/pretty.js'
-import { downloadTSV } from '@/modules/utils';
+import { downloadTSV, toCURIE, toIRI } from '@/modules/utils';
 
 const basePath = import.meta.env.BASE_URL || '/';
 
 export function useGraphData(config) {
 
-  const defaultURL = `${basePath}dlschemas_data.ttl`
-  const graphData = createReactiveDataset();
-  const serializedGraphData = ref('');
-  const graphTriples = ref([]);
-  var graphPrefixes = reactive({});
-	var prefixArray = ref([]);
-	var prefixes_ready = ref(false);
-  const rdfPretty = rdf.clone()
-  rdfPretty.formats.import(formatsPretty)
-  const batchMode = ref(false);
+    const defaultURL = `${basePath}dlschemas_data.ttl`
+    const graphData = createReactiveDataset();
+    const serializedGraphData = ref('');
+    const graphTriples = ref([]);
+    var graphPrefixes = reactive({});
+        var prefixArray = ref([]);
+        var prefixes_ready = ref(false);
+    const rdfPretty = rdf.clone()
+    rdfPretty.formats.import(formatsPretty)
+    const batchMode = ref(false);
+    const fetchedRequests = new Set()
 
-
-  async function getGraphData(url) {
-    // Get graph data from url, provided either as argument (highest priority),
-    // via config (mid priority), or base default (lowest priority), or get no data
-    // if specified via config
-    var getURL
-    if (!url) {
-      // If no url argument provided, check config
-      // Config priority is:
-      // - if the data_url is provided, use it and ignore use_default_data
-      // - if the data_url is NOT provided, use default if use_default_data==true, else nothing
-      if (config.value.data_url) {
-        if (config.value.data_url.indexOf('http')>=0) {
-          getURL = config.value.data_url
-        } else {
-          getURL = `${basePath}${config.value.data_url}`;
-        }
-      } else {
-        if (config.value.use_default_data == true) {
-          getURL = defaultURL
-        } else {
-          console.log("getGraphData -> no url provided via argument or config, and config specifies not to use default; not fetching")
-          updateSerializedData();
-          triggerReactivity();
-          return
-        }
-      }
-    } else {
-      getURL = url
-    }
-
-    console.log(getURL)
-
-    batchMode.value = true;
-		readRDF(getURL)
-		.then(quadStream => {
-			// Load prefixes
-			quadStream.on('prefix', (prefix, ns) => {
-				graphPrefixes[prefix] = ns.value;
-				prefixArray.value.push(ns.value)
-			}).on('end', () => {
-				prefixes_ready.value = true
-			})
-			// Load data
-			quadStream.on('data', quad => {
-				graphData.add(quad)
-			}).on('end', () => {
-        updateSerializedData();
-        triggerReactivity();
-        batchMode.value = false;
-      });
-		})
-		.catch(error => {
-			console.error('Error reading TTL data:', error);
-		});
-	}
-
-  async function updateSerializedData() {
-    serializedGraphData.value = (await rdfPretty.io.dataset.toText('text/turtle', graphData)).trim()
-  }
-
-  watch(graphData, async () => {
-    await updateSerializedData();
-    updateGraphTriples();
-  }, { deep: true });
-
-
-  function updateGraphTriples() {
-    var gt = []
-    graphData.forEach(quad => {
-      gt.push(`${quad.subject.value} - ${quad.predicate.value} - ${quad.object.value}`)
-    });
-    graphTriples.value = gt
-  }
-
-  function createReactiveDataset() {
-    const dataset = rdf.dataset();
-    const proxy = new Proxy(dataset, {
-      get(target, prop, receiver) {
-        const value = Reflect.get(target, prop, receiver);
-        if (typeof value === 'function' && ['add', 'delete', 'deleteMatches', 'toCanonical', 'toStream', 'toString'].includes(prop)) {
-          return function (...args) {
-            const result = value.apply(target, args);
-            if (!batchMode.value) {
-              triggerReactivity(); // Trigger reactivity when dataset is mutated
+    async function getGraphData(url) {
+        return new Promise((resolve, reject) => {
+            // Get graph data from url, provided either as argument (highest priority),
+            // via config (mid priority), or base default (lowest priority), or get no data
+            // if specified via config
+            var getURL
+            if (!url) {
+                // If no url argument provided, check config
+                // Config priority is:
+                // - if the data_url is provided, use it and ignore use_default_data
+                // - if the data_url is NOT provided, use default if use_default_data==true, else nothing
+                if (config.value.data_url) {
+                    if (config.value.data_url.indexOf('http')>=0) {
+                        getURL = config.value.data_url
+                    } else {
+                        getURL = `${basePath}${config.value.data_url}`;
+                    }
+                } else {
+                    if (config.value.use_default_data == true) {
+                        getURL = defaultURL
+                    } else {
+                        console.log("getGraphData -> no url provided via argument or config, and config specifies not to use default; not fetching")
+                        updateSerializedData();
+                        triggerReactivity();
+                        resolve();
+                        return
+                    }
+                }
+            } else {
+                getURL = url
             }
-            return result;
-          };
-        }
-        return value;
-      }
-    });
-
-    // Initialize the dummy property to ensure reactivity
-    proxy._dummy = false;
-
-    return reactive(proxy);
-  }
-
-  function triggerReactivity() {
-    // Toggle the dummy property to trigger reactivity
-    graphData._dummy = !graphData._dummy;
-  }
-
-  async function serializeNodesToTSV() {
-    const nodeType = 'https://concepts.datalad.org/s/sddnb/unreleased/StudySample';
-    const propertyURIs = [
-      'https://concepts.datalad.org/s/sddnb/unreleased/participant_id',
-      'https://concepts.datalad.org/s/sddnb/unreleased/session_id',
-      'https://concepts.datalad.org/s/sddnb/unreleased/pheno_age',
-      'https://concepts.datalad.org/s/sddnb/unreleased/pheno_group',
-      'https://concepts.datalad.org/s/sddnb/unreleased/pheno_sex',
-      'https://concepts.datalad.org/s/sddnb/unreleased/tool1_item1',
-      'https://concepts.datalad.org/s/sddnb/unreleased/tool1_item2',
-      'https://concepts.datalad.org/s/sddnb/unreleased/tool2_item1'
-    ];
-    const filename = 'StudySamples.tsv'
-    // Define the headers for the TSV
-    const headers = propertyURIs.map(uri => uri.split('/').pop()); // Extract local name for headers
-    let tsvData = headers.join('\t') + '\n'; // Column headers
-
-    // Use the graph to find all nodes of the specified type
-    const predicate = rdf.namedNode(RDF.type.value)
-    const nodes = rdf.grapoi({ dataset: graphData })
-            .hasOut(predicate, rdf.namedNode(nodeType))
-            .quads();
-
-    // Iterate over each node
-    for (const quad of nodes) {
-      const node = quad.subject;
-
-      // Collect property values for the current node
-      const row = [];
-      for (const propertyURI of propertyURIs) {
-        // Use the graph to find the value for each property
-        const valueQuad = Array.from(graphData.match(node, rdf.namedNode(propertyURI)));
-
-        // Push value or empty if not found
-        if (valueQuad.length > 0) {
-          const value = valueQuad[0].object;
-          // Handle literal values (e.g., strings, numbers) and URIs
-          if (value.termType === 'Literal') {
-            row.push(value.value);
-          } else if (value.termType === 'NamedNode') {
-            row.push(value.value); // URI value
-          }
-        } else {
-          row.push(''); // Empty if no value found
-        }
-      }
-      tsvData += row.join('\t') + '\n'; // Add row to TSV data
+            batchMode.value = true;
+            readRDF(getURL)
+                .then(quadStream => {
+                    // Load prefixes
+                    quadStream.on('prefix', (prefix, ns) => {
+                        graphPrefixes[prefix] = ns.value;
+                        prefixArray.value.push(ns.value)
+                    }).on('end', () => {
+                        prefixes_ready.value = true
+                    })
+                    // Load data
+                    quadStream.on('data', quad => {
+                        graphData.add(quad)
+                    }).on('end', () => {
+                        updateSerializedData();
+                        triggerReactivity();
+                        batchMode.value = false;
+                        resolve();
+                    }).on('error', (error) => {
+                        console.error('Error in quadStream:', error);
+                        resolve()
+                    });
+                })
+                .catch(error => {
+                    console.error('Error reading TTL data:', error);
+                    resolve()
+                });
+        })
     }
 
-    // Trigger the download of the TSV file
-    downloadTSV(tsvData, filename);
-  }
+    async function updateSerializedData() {
+        serializedGraphData.value = (await rdfPretty.io.dataset.toText('text/turtle', graphData)).trim()
+    }
 
-  
+    watch(graphData, async () => {
+        await updateSerializedData();
+        updateGraphTriples();
+    }, { deep: true });
+
+
+    function updateGraphTriples() {
+        var gt = []
+        graphData.forEach(quad => {
+            gt.push(`${quad.subject.value} - ${quad.predicate.value} - ${quad.object.value}`)
+        });
+        graphTriples.value = gt
+    }
+
+    function createReactiveDataset() {
+        const dataset = rdf.dataset();
+        const proxy = new Proxy(dataset, {
+            get(target, prop, receiver) {
+                const value = Reflect.get(target, prop, receiver);
+                if (typeof value === 'function' && ['add', 'delete', 'deleteMatches', 'toCanonical', 'toStream', 'toString'].includes(prop)) {
+                    return function (...args) {
+                        const result = value.apply(target, args);
+                        if (!batchMode.value) {
+                            triggerReactivity(); // Trigger reactivity when dataset is mutated
+                        }
+                        return result;
+                    };
+                }
+                return value;
+            }
+        });
+        // Initialize the dummy property to ensure reactivity
+        proxy._dummy = false;
+        return reactive(proxy);
+    }
+
+    function triggerReactivity() {
+        // Toggle the dummy property to trigger reactivity
+        graphData._dummy = !graphData._dummy;
+    }
+
+
+    async function fetchFromService(endpoint, arg, prefixes) {
+        const serviceBaseURL = config.value.service_base_url
+        const serviceEndpoints = config.value.service_endpoints
+        if (!(serviceBaseURL || serviceEndpoints)) {
+            console.error("Service base URL and/or service endpoints not included in configuration.\nFetching data from an endpoint will not be possible.")
+            return
+        }
+
+        if (Object.keys(serviceEndpoints).indexOf(endpoint) < 0) {
+            console.log(`Unknown endpoint '${endpoint}' provided; continuing without making a request to configured service`)
+            return
+        }
+        const query_string = replaceServiceIdentifier(arg, serviceEndpoints[endpoint], prefixes)
+        console.log(query_string)
+        var getURL = `${serviceBaseURL}${query_string}`
+        if (fetchedRequests.has(getURL)) {
+            console.log(`Skipping request: Data previously fetched from ${getURL}`);
+            return;
+        }
+
+        fetchedRequests.add(getURL);
+
+        return new Promise((resolve, reject) => {
+            getGraphData(getURL)
+                .then(() => {
+                    resolve();  // Resolve the promise when getGraphData is done
+                })
+                .catch(error => {
+                    console.error(error);
+                    fetchedRequests.delete(getURL);
+                    reject(error);
+                });
+        });
+    }
+
+    function replaceServiceIdentifier(id, arg_string, prefixes) {
+        // e.g.: "record?id={curie}&format=ttl";
+
+        // First extract the part inside the curly brackets
+        const id_type = arg_string.match(/{(.*?)}/)[1];
+        var replacement_id
+        console.log(`id_type = ${id_type}`)
+
+        if (id_type == "curie") {
+            replacement_id = toCURIE(id, prefixes)
+        } else if (id_type == "name") {
+            replacement_id = toCURIE(id, prefixes, "parts").property
+        } else if (id_type == "uri") {
+            replacement_id = id
+        } else {
+            replacement_id = id
+        }
+        console.log(replacement_id)
+        // Replace curly brackets and everything in between
+        return arg_string.replace(/{.*?}/, encodeURIComponent(replacement_id));
+    }
 
     // expose managed state as return value
     return {
-      graphData,
-      batchMode,
-      getGraphData,
-      graphPrefixes,
-      serializedGraphData,
-      graphTriples,
-      serializeNodesToTSV,
-      updateSerializedData,
-      triggerReactivity
+        graphData,
+        batchMode,
+        getGraphData,
+        graphPrefixes,
+        serializedGraphData,
+        graphTriples,
+        updateSerializedData,
+        triggerReactivity,
+        fetchFromService
     }
-  }
+}

--- a/src/composables/tokens.js
+++ b/src/composables/tokens.js
@@ -1,0 +1,19 @@
+// src/composables/tokens.js
+import { ref } from 'vue';
+
+const tokenName = "serviceToken";
+const token = ref(sessionStorage.getItem(tokenName) || null);
+
+export function useToken() {
+  const setToken = (newToken) => {
+    token.value = newToken;
+    sessionStorage.setItem(tokenName, newToken);
+  };
+
+  const clearToken = () => {
+    token.value = null;
+    sessionStorage.removeItem(tokenName);
+  };
+
+  return { token, setToken, clearToken };
+}

--- a/src/modules/io.js
+++ b/src/modules/io.js
@@ -10,38 +10,103 @@
 
 import formats from '@rdfjs/formats-common'
 import fetch from '@rdfjs/fetch-lite'
+import formatsPretty from '@rdfjs/formats/pretty.js'
+import rdf from 'rdf-ext'
+import { useToken } from '@/composables/tokens'
+
+// clone the default environment
+const rdfPretty = rdf.clone()
+// import pretty print serializers
+rdfPretty.formats.import(formatsPretty)
 
 export async function readRDF(file_url, headers = { "Content-Type": "text/turtle" }) {
-    var res = null
-    res = await fetch(file_url,
-        {
-            formats, 
-            headers: headers
-        }
-    )
-    console.log(res.headers)
-    // Handle cases where the server returns generic 'text/plain' or 'text/html' content type
-    if (['text/plain', 'text/html'].indexOf(res.headers.get('content-type')) >= 0) {
-        // default to turtle
-        headers['Content-Type'] = 'text/turtle';
-        res = await fetch(file_url, { formats, headers });
-    }
 
-    const quadStream = await res.quadStream()
-    // quadStream.on('error', err => console.error(err))
-    return quadStream
-    // Examples of what to do with the quadstream:
-    // 
-    //   - quadStream.on('error', err => console.error(err))
-    //   - quadStream.on('prefix', (prefix, ns) => {
-    //         console.log(`prefix: ${prefix} ${ns.value}`)
-    //     })
-    //   - quadStream.on('data', quad => {
-    //         console.log(`${quad.subject.value} - ${quad.predicate.value} -  ${quad.object.value}`)
-    //     })
-    //   -  quadStream.on('prefix', (prefix, ns) => {
-    //          // do something for every prefix
-    //      }).on('end', () => {
-    //          // do something at the end of all prefixes
-    //      })
+    try {
+        const { token } = useToken();
+        if (token.value) {
+            headers['X-DumpThings-Token'] = token.value;
+        }
+        var res = null
+        res = await fetch(file_url,
+            {
+                formats, 
+                headers: headers
+            }
+        )
+        // Handle cases where the server returns generic 'text/plain' or 'text/html' content type
+        if (['text/plain', 'text/html'].indexOf(res.headers.get('content-type')) >= 0) {
+            // default to turtle
+            headers['Content-Type'] = 'text/turtle';
+            res = await fetch(file_url, { formats, headers });
+        }
+
+        if (res.ok) {
+            if (res.headers.get('content-type').indexOf('application/json') >= 0) {
+                console.log(res.json())
+                throw new Error(`readRDF error: cannot read json data`);
+
+            }
+            const quadStream = await res.quadStream()
+            // quadStream.on('error', err => console.error(err))
+            return quadStream
+        } else {
+            throw new Error(`readRDF error:: ${res.statusText}`);
+        }
+
+        
+        // Examples of what to do with the quadstream:
+        // 
+        //   - quadStream.on('error', err => console.error(err))
+        //   - quadStream.on('prefix', (prefix, ns) => {
+        //         console.log(`prefix: ${prefix} ${ns.value}`)
+        //     })
+        //   - quadStream.on('data', quad => {
+        //         console.log(`${quad.subject.value} - ${quad.predicate.value} -  ${quad.object.value}`)
+        //     })
+        //   -  quadStream.on('prefix', (prefix, ns) => {
+        //          // do something for every prefix
+        //      }).on('end', () => {
+        //          // do something at the end of all prefixes
+        //      })
+
+    } catch (error) {
+        console.error('readRDF error:', error);
+        throw error;
+    }
+    
 }
+
+
+export async function postRDF(endpoint, dataset, format = 'text/turtle', headers = {}) {
+    try {
+        const { token } = useToken();
+        if (token.value) {
+            headers['X-DumpThings-Token'] = token.value;
+        }
+
+        // Ensure we have the correct content-type
+        headers['Content-Type'] = format;
+
+        // Serialize the dataset to the desired format
+        const body = await rdfPretty.io.dataset.toText('text/turtle', dataset)
+
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers,
+            body,
+        });
+
+        if (!response.ok) {
+            throw new Error(`postRDF error: ${response.statusText}`);
+        }
+
+        return response;
+    } catch (error) {
+        console.error('postRDF error:', error);
+        throw error;
+    }
+}
+
+
+
+

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -49,7 +49,6 @@ export function toIRI(CURIE, prefixes) {
   var pref = parts[0]
   var prop = parts[1]
   if (Object.keys(prefixes).indexOf(pref) < 0) {
-    console.log("unknown prefix in curie, returning")
     return CURIE
   }
   return prefixes[pref] + prop


### PR DESCRIPTION
Apart from some styling and UX updates, this PR mainly advances the service integration functionality, i.e. fetching metadata from a configurable endpoint, and pushing updated metadata to a configurable endpoint.

Summary:
- Adds configurable opt-in functionality for fetching data from service endpoints. The main changes include:
   - new additions to the config file to opt in to this function and to provide the endpoints with parameterization
   - including functions for fetching data in the main shaclvue component (multiple records of a class, and a single record by id) and the InstancesSelectEditor.
   - adding the actual request funcitonality to the graphdata composable. This changes the workflow to return promises which is also why the dynamic component instantiation code in the propertyshapeeditor has to be wrapped in a suspense tag.
   - a new update to read additional prefixes from config
- Adds base functionality for user to add a token: adds the composables and components and further functions for asking for a token to be entered when a user opts to submit their edited data. The token is stored in sessionStorage and subsequently made part of any future GET or POST request to the configured service. Submit button is a simple icon in the app header bar.
- WIP functionality for form submission:
   - io is updated to allow POST requests using the fetch-lite package
   - io now handles error responses in an improved way
   - formdata composable is updated to include generalised functionality for handling conversion of form data to quads in an rdf.dataset (TODO: refactor the existing saveForm funcitonality to use this)

Form submission is now ready to be tested locally.
