### PR TITLE
Helpers for getting default schemas and data

### DIFF
--- a/public/dlschemas_data.ttl
+++ b/public/dlschemas_data.ttl
@@ -9,6 +9,7 @@
 @prefix dlres: <https://concepts.datalad.org/s/resources/unreleased/> .
 @prefix dlroles: <https://concepts.datalad.org/s/roles/unreleased/> .
 @prefix dlsocial: <https://concepts.datalad.org/s/social/unreleased/> .
+@prefix dlspatial: <https://concepts.datalad.org/s/agents/unreleased/> .
 @prefix dltemporal: <https://concepts.datalad.org/s/agents/unreleased/> .
 @prefix dlthings: <https://concepts.datalad.org/s/things/v1/> .
 @prefix ex: <http://example.org/> .
@@ -25,113 +26,88 @@
 @prefix w3ctr: <https://www.w3.org/TR/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://dbpedia.org/resource/Madrid> a dltemporal:Location .
-
-ex:day a dltemporal:InstantaneousEvent ;
-    dltemporal:at_time "1984-05-14"^^w3ctr:NOTE-datetime .
-
-ex:min a dltemporal:InstantaneousEvent ;
-    dltemporal:at_time "1984-05-14T15:32"^^w3ctr:NOTE-datetime .
-
-ex:month a dltemporal:InstantaneousEvent ;
-    dltemporal:at_time "1785-02"^^w3ctr:NOTE-datetime .
-
-<http://example.org/ns/people/jane> a dlprov:Agent,
-        dlsocial:Person ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "email:jane@example.org"^^xsd:anyURI ;
-            dlroles:roles <http://schema.org/email> ],
-        [ a dlroles:Relationship ;
-            rdf:object "geo:-19.738897,63.453072?z=19"^^xsd:anyURI ;
-            dlroles:roles obo:NCIT_C17556 ],
-        [ a dlroles:Relationship ;
-            rdf:object "geo:-19.738897,63.453072?z=19"^^xsd:anyURI ;
-            dlroles:roles obo:NCIT_C17556 ] .
-
-<http://example.org/ns/zorro> a dlsocial:Person ;
-    dlsocial:additional_names "Zorro" ;
-    dlsocial:family_name "de la Vega" ;
-    dlsocial:formatted_name "Don Diego Zorro de la Vega III" ;
-    dlsocial:given_name "Diego" ;
-    dlsocial:honorific_name_prefix "Don" ;
-    dlsocial:honorific_name_suffix "III" .
-
-<http://example.org/projects/p1a> a dlsocial:Project ;
-    dlprops:description "A project about approaching a new field, and not looking entirely incompetent after some time." ;
-    dlprops:short_name "BANG!" ;
-    dlprops:title "Impactful entry" ;
-    dlprov:associated_with <http://orcid.org/0000-0001-6398-6370> ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "http://orcid.org/0000-0001-6398-6370"^^xsd:anyURI ;
-            dlroles:roles marcrel:ctb ] ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate <http://example.org/ns/psych/self-esteem-boost-potential> ;
-            rdfs:range "linkml:int"^^xsd:anyURI ;
-            rdfs:value "100" ] ;
-    dlthings:characterized_by [ a dlthings:Statement ;
-            rdf:object "ex:projects/grand-plan"^^xsd:anyURI ;
-            rdf:predicate ex:isPartOf ] .
-
 ex:second a dltemporal:InstantaneousEvent ;
     dltemporal:at_time "1982-01-59T15:32:44"^^w3ctr:NOTE-datetime .
 
-ex:subsecond-with-timezone a dltemporal:InstantaneousEvent ;
-    dltemporal:at_time "2021-01-31T01:22:33.4321+06:00"^^w3ctr:NOTE-datetime .
+
+
+<https://en.wikipedia.org/wiki/Death_of_Freddie_Mercury> a dltemporal:InstantaneousEvent .
+
+
 
 ex:triassic a dltemporal:InstantaneousEvent ;
     dltemporal:at_time "-201000000"^^w3ctr:NOTE-datetime .
 
+
+
 ex:year a dltemporal:InstantaneousEvent ;
     dltemporal:at_time "1532"^^w3ctr:NOTE-datetime .
 
-marcrel:this a dlroles:Role .
 
-<http://orcid.org/0000-0001-7628-0801> a dlprov:Agent,
-        dlsocial:Person .
 
-<https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv> a dldist:Distribution ;
-    dlco:qualified_access [ a dldist:QualifiedAccess ;
-            dldist:access_service <https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795> ] ;
-    dldist:byte_size "3214"^^xsd:nonNegativeInteger ;
-    dldist:checksum [ a dlidentifiers:Checksum ;
-            dlidentifiers:creator "spdx:checksumAlgorithm_md5"^^xsd:anyURI ;
-            dlidentifiers:notation "ba1f2511fc30423bdbb183fe33f3dd0f"^^xsd:hexBinary ] ;
-    dldist:media_type "text/csv" .
+ex:subsecond-with-timezone a dltemporal:InstantaneousEvent ;
+    dltemporal:at_time "2021-01-31T01:22:33.4321+06:00"^^w3ctr:NOTE-datetime .
 
-gitsha:9a48c2bf7e97a081f2b1ab68eb909bbfc86267be a dldist:Distribution ;
-    dldist:is_distribution_of gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f ;
-    dldist:qualified_part [ a dldist:DistributionPart ;
-            rdf:object "https://concepts.datalad.org/ns/gitsha/e12e9505cff5417f594d719b99720b4c39d86434"^^xsd:anyURI ;
-            dlprops:name "index.html" ],
-        [ a dldist:DistributionPart ;
-            rdf:object "https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"^^xsd:anyURI ;
-            dlprops:name "table.csv" ] .
 
-gitsha:e12e9505cff5417f594d719b99720b4c39d86434 a dldist:Distribution ;
-    dldist:byte_size "63165"^^xsd:nonNegativeInteger ;
-    dldist:checksum [ a dlidentifiers:Checksum ;
-            dlidentifiers:creator "spdx:checksumAlgorithm_sha1"^^xsd:anyURI ;
-            dlidentifiers:notation "0410b851ebd2282ac37558885db16782f31626db"^^xsd:hexBinary ] ;
-    dldist:media_type "text/html" .
 
-<https://doi.org/10.1038/s41597-022-01163-2> a dlpubs:Publication,
-        dlthings:Thing ;
+ex:month a dltemporal:InstantaneousEvent ;
+    dltemporal:at_time "1785-02"^^w3ctr:NOTE-datetime .
+
+
+
+ex:min a dltemporal:InstantaneousEvent ;
+    dltemporal:at_time "1984-05-14T15:32"^^w3ctr:NOTE-datetime .
+
+
+
+ex:day a dltemporal:InstantaneousEvent ;
+    dltemporal:at_time "1984-05-14"^^w3ctr:NOTE-datetime .
+
+
+
+<http://example.org/ns/people/jane> a dlprov:Agent ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "geo:-19.738897,63.453072?z=19"^^xsd:anyURI ;
+            dlroles:roles obo:NCIT_C17556 ] .
+
+
+
+<http://orcid.org/0000-0001-7628-0801> a dlprov:Agent .
+
+
+
+<https://orcid.org/0000-0001-6398-6370> a dlprov:Agent ;
+    dlprov:acted_on_behalf_of <https://ror.org/02nv7yv05> ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate foaf:name ;
+            rdfs:value "Michael Hanke" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate <http://www.bioassayontology.org/bao#BAO_0002826> ;
+            rdfs:value "1" ] .
+
+
+
+<https://doi.org/10.1038/s41597-022-01163-2> a dlpubs:Publication ;
     dlprops:about "https://www.nature.com/subjects/data-processing"^^xsd:anyURI,
         "https://www.nature.com/subjects/data-publication-and-archiving"^^xsd:anyURI,
         "https://www.nature.com/subjects/software"^^xsd:anyURI ;
     dlprops:description "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)." ;
     dlprops:title "FAIRly big: A framework for computationally reproducible processing of large-scale data" ;
-    skos:exactMatch "bibo:AcademicArticle"^^xsd:anyURI ;
     dltemporal:date_modified "2022-02-11"^^w3ctr:NOTE-datetime ;
-    dltemporal:date_published "2022-03-11"^^w3ctr:NOTE-datetime ;
+    dltemporal:date_published "2022-03-11"^^w3ctr:NOTE-datetime .
+
+
+
+<https://doi.org/10.1038/s41597-022-01163-2> a dlpubs:Publication .
+
+
+
+<https://doi.org/10.1038/s41597-022-01163-2> a dlpubs:Publication ;
     dlidentifiers:identifier [ a dlidentifiers:DOI ;
             dlidentifiers:creator "https://doi.org"^^xsd:anyURI ;
             dlidentifiers:notation "10.1038/s41597-022-01163-2" ;
             dlidentifiers:schema_agency "DOI Foundation" ] ;
     dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "https://orcid.org/0000-0002-8402-6173"^^xsd:anyURI ;
-            dlroles:roles marcrel:aut ],
-        [ a dlroles:Relationship ;
             rdf:object "https://orcid.org/0000-0001-7163-3110"^^xsd:anyURI ;
             dlroles:roles marcrel:aut ],
         [ a dlroles:Relationship ;
@@ -159,108 +135,21 @@ gitsha:e12e9505cff5417f594d719b99720b4c39d86434 a dldist:Distribution ;
                 obo:NCIT_C25461 ],
         [ a dlroles:Relationship ;
             rdf:object "https://orcid.org/0000-0001-6363-2759"^^xsd:anyURI ;
-            dlroles:roles marcrel:aut ] ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate bibo:number ;
-            rdfs:value "80" ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ex:title ;
-                    rdfs:value "Document number" ] ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:date ;
-            rdfs:range "xsd:date"^^xsd:anyURI ;
-            rdfs:value "2022-03-11" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:bibliographicCitation ;
-            rdfs:value "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)." ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:title ;
-            rdfs:value "FAIRly big: A framework for computationally reproducible processing of large-scale data" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)." ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate bibo:numPages ;
-            rdfs:range "xsd:nonNegativeInteger"^^xsd:anyURI ;
-            rdfs:value "17" ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ex:title ;
-                    rdfs:value "Number of pages" ] ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate bibo:doi ;
-            rdfs:value "https://doi.org/10.1038/s41597-022-01163-2" ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ex:title ;
-                    rdfs:value "DOI" ] ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:identifier ;
-            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ADMS:schemaAgency ;
-                    rdfs:value "https://doi.org" ],
-                [ a dlthings:AttributeSpecification ;
-                    rdf:predicate skos:notation ;
-                    rdfs:value "10.1038/s41597-022-01163-2" ] ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:modified ;
-            rdfs:range "xsd:date"^^xsd:anyURI ;
-            rdfs:value "2022-02-11" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate bibo:volume ;
-            rdfs:value "9" ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ex:title ;
-                    rdfs:value "Volume" ] ] ;
-    dlthings:characterized_by [ a dlthings:Statement ;
-            rdf:object "https://www.nature.com/subjects/software"^^xsd:anyURI ;
-            rdf:predicate ex:subject ],
-        [ a dlthings:Statement ;
-            rdf:object "https://www.nature.com/subjects/data-publication-and-archiving"^^xsd:anyURI ;
-            rdf:predicate ex:subject ],
-        [ a dlthings:Statement ;
-            rdf:object "https://portal.issn.org/resource/issn/2052-4463"^^xsd:anyURI ;
-            rdf:predicate ex:isPartOf ],
-        [ a dlthings:Statement ;
-            rdf:object "https://www.nature.com/subjects/data-processing"^^xsd:anyURI ;
-            rdf:predicate ex:subject ],
-        [ a dlthings:Statement ;
-            rdf:object "https://spdx.org/licenses/CC-BY-4.0"^^xsd:anyURI ;
-            rdf:predicate ex:license ],
-        [ a dlthings:Statement ;
-            rdf:object "https://www.nature.com/articles/s41597-022-01163-2"^^xsd:anyURI ;
-            rdf:predicate owl:sameAs ] ;
-    dlthings:relation <https://portal.issn.org/resource/issn/2052-4463> .
+            dlroles:roles marcrel:aut ],
+        [ a dlroles:Relationship ;
+            rdf:object "https://orcid.org/0000-0002-8402-6173"^^xsd:anyURI ;
+            dlroles:roles marcrel:aut ] .
 
-<https://doi.org/10.21105/joss.03262> a dlthings:Thing ;
-    dlthings:characterized_by [ a dlthings:Statement ;
-            rdf:object "https://www.scicrunch.org/resolver/SCR_003931"^^xsd:anyURI ;
-            rdf:predicate ex:subject ] ;
-    dlthings:relation <https://portal.issn.org/resource/issn/2475-9066>,
-        <https://www.scicrunch.org/resolver/SCR_003931> .
 
-<https://en.wikipedia.org/wiki/Death_of_Freddie_Mercury> a dltemporal:InstantaneousEvent .
 
-<https://example.org/ns/datasetversion/.> a dldist:Distribution ;
-    dldist:has_part <https://example.org/ns/datasetversion/./dataset_description.json>,
-        <https://example.org/ns/datasetversion/./participants.tsv> ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:conformsTo ;
-            rdfs:range "uri"^^xsd:anyURI ;
-            rdfs:value "https://bids-specification.readthedocs.io/en/v1.4.0" ] .
+<https://gepris.dfg.de/gepris/projekt/546006540> a dlres:Grant .
 
-<https://example.org/ns/datasetversion/./archive.zip> a dldist:Distribution ;
-    dldist:has_part <https://example.org/ns/datasetversion/./archive.zip/subdir> ;
-    dldist:qualified_part [ a dldist:DistributionPart ;
-            rdf:object "exthisdsver:./archive.zip/subdir"^^xsd:anyURI ;
-            dlprops:name "subdir" ] .
 
-<https://example.org/ns/datasetversion/./file.jpeg> a dldist:Distribution ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "obo:NCIT_C95650"^^xsd:anyURI ;
-            dlroles:roles obo:NCIT_C42645 ] ;
-    dlthings:characterized_by [ a dlthings:Statement ;
-            rdf:object "obo:NCIT_C95650"^^xsd:anyURI ;
-            rdf:predicate obo:NCIT_C42645 ] .
+
+<https://gepris.dfg.de/gepris/projekt/546006540> a dlres:Grant ;
+    dlres:sponsor <https://ror.org/018mejw64> .
+
+
 
 <https://example.org/ns/datasetversion/./some/name.ext> a dldist:Distribution ;
     dltemporal:date_modified "2024-03-21"^^w3ctr:NOTE-datetime ;
@@ -276,99 +165,124 @@ gitsha:e12e9505cff5417f594d719b99720b4c39d86434 a dldist:Distribution ;
             rdf:predicate foaf:name ;
             rdfs:value "name.ext" ] .
 
-<https://example.org/ns/datasetversion/./some/path.ext> a dldist:Distribution ;
+
+
+<https://example.org/ns/datasetversion/.> a dldist:Distribution ;
+    dldist:has_part <https://example.org/ns/datasetversion/./dataset_description.json>,
+        <https://example.org/ns/datasetversion/./participants.tsv> ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:conformsTo ;
+            rdfs:range "uri"^^xsd:anyURI ;
+            rdfs:value "https://bids-specification.readthedocs.io/en/v1.4.0" ] .
+
+<https://example.org/ns/datasetversion/./dataset_description.json> a dldist:Distribution ;
+    dldist:media_type "application/json" .
+
+<https://example.org/ns/datasetversion/./participants.tsv> a dldist:Distribution ;
+    dldist:format "http://edamontology.org/format_3475"^^xsd:anyURI .
+
+
+
+<https://example.org/ns/datasetversion/./file.jpeg> a dldist:Distribution ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "obo:NCIT_C95650"^^xsd:anyURI ;
+            dlroles:roles obo:NCIT_C42645 ] ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object "obo:NCIT_C95650"^^xsd:anyURI ;
+            rdf:predicate obo:NCIT_C42645 ] .
+
+
+
+gitsha:e12e9505cff5417f594d719b99720b4c39d86434 a dldist:Distribution ;
+    dldist:byte_size "63165"^^xsd:nonNegativeInteger ;
+    dldist:checksum [ a dlidentifiers:Checksum ;
+            dlidentifiers:creator "spdx:checksumAlgorithm_sha1"^^xsd:anyURI ;
+            dlidentifiers:notation "0410b851ebd2282ac37558885db16782f31626db"^^xsd:hexBinary ] ;
+    dldist:media_type "text/html" .
+
+
+
+<https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv> a dldist:Distribution ;
     dlco:qualified_access [ a dldist:QualifiedAccess ;
-            dldist:access_service <https://coscine.example.org> ] ;
-    dldist:access_service <https://coscine.example.org> ;
-    dldist:access_url "https://coscine.example.org/coscine"^^xsd:anyURI ;
-    dldist:download_url "https://coscine.example.org/coscine/api/v2/projects/p123/resources/r456/blobs/k789"^^xsd:anyURI,
-        "https://www.example.org/path.ext"^^xsd:anyURI ;
+            dldist:access_service <https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795> ] .
+
+
+
+<https://example.org/ns/datasetversion/./some/path.ext> a dldist:Distribution ;
     dldist:is_distribution_of <https://example.org/ns/datasetversion/#some/path> ;
-    dldist:license <https://example.org/ns/dataset/#customlicense> ;
-    dlthings:relation <https://coscine.example.org>,
-        <https://example.org/ns/dataset/#>,
-        <https://example.org/ns/dataset/#customlicense>,
+    dlthings:relation <https://example.org/ns/dataset/#>,
         <https://example.org/ns/datasetversion/#>,
         <https://example.org/ns/datasetversion/#some/path> .
 
-exthisns:measurement853 a dlthings:ValueSpecification ;
-    rdfs:range "xsd:decimal"^^xsd:anyURI ;
-    rdfs:value "145.3",
-        "special" ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:title ;
-            rdfs:value "measured mass (kg)" ] ;
-    dlthings:characterized_by [ a dlthings:Statement ;
-            rdf:object "obo:IAO_0000109"^^xsd:anyURI ;
-            rdf:predicate ex:subject ],
-        [ a dlthings:Statement ;
-            rdf:object "obo:PATO_0000125"^^xsd:anyURI ;
-            rdf:predicate ex:subject ],
-        [ a dlthings:Statement ;
-            rdf:object "obo:UO_0000009"^^xsd:anyURI ;
-            rdf:predicate obo:UO_0000000 ] .
-
-exthisns:mything a dlthings:Thing .
-
-<https://gepris.dfg.de/gepris/projekt/546006540> a dlres:Grant ;
-    dlres:sponsor <https://ror.org/018mejw64> .
-
-<https://orcid.org/0000-0001-6398-6370> a dlprov:Agent,
-        dlsocial:Person ;
-    dlprov:acted_on_behalf_of <https://ror.org/02nv7yv05> ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate foaf:name ;
-            rdfs:value "Michael Hanke" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate <http://www.bioassayontology.org/bao#BAO_0002826> ;
-            rdfs:value "1" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate <http://www.bioassayontology.org/bao#BAO_0002826> ;
-            rdfs:value "1" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate foaf:name ;
-            rdfs:value "Michael Hanke" ] .
-
-<https://trr379.de> a dlsocial:Organization ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "https://ror.org/018mejw64"^^xsd:anyURI ;
-            dlroles:roles marcrel:fnd ] .
-
-ex:modified a dlthings:Property ;
+<https://example.org/ns/dataset/#> a dldist:Resource ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
             rdf:predicate ex:description ;
-            rdfs:value "Date on which the resource was changed." ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:title ;
-            rdfs:value "modified" ] .
+            rdfs:value "A collection of some data" ] .
 
-<https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795> a dldist:DataService ;
-    skos:exactMatch "https://git-annex.branchable.com/special_remotes"^^xsd:anyURI ;
-    dldist:endpoint_description "https://git-annex.branchable.com/special_remotes/webdav/"^^xsd:anyURI ;
-    dldist:endpoint_url "https://dav.box.com/dav/git-annex"^^xsd:anyURI ;
+<https://example.org/ns/datasetversion/#> a dldist:Resource ;
+    dldist:is_version_of <https://example.org/ns/dataset/#> ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:identifier ;
-            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate skos:notation ;
-                    rdfs:value "0a8713ca-ef42-11ee-a805-d3e9a774e795" ],
-                [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ADMS:schemaAgency ;
-                    rdfs:value "https://git-annex.branchable.com" ] ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate foaf:name ;
-            rdfs:value "box.com" ] .
+            rdf:predicate ex:description ;
+            rdfs:value "A version of a collection of some data\"" ] .
 
-<https://concepts.datalad.org/ns/dataset-uuid/cec1da92-0dbd-4df3-8602-7c72b2d12854> a dldist:Resource ;
+<https://example.org/ns/datasetversion/#some/path> a dldist:Resource ;
+    dldist:is_part_of <https://example.org/ns/datasetversion/#> ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:identifier ;
-            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate skos:notation ;
-                    rdfs:value "cec1da92-0dbd-4df3-8602-7c72b2d12854" ],
-                [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ADMS:schemaAgency ;
-                    rdfs:value "https://datalad.org" ] ] .
+            rdf:predicate ex:description ;
+            rdfs:value "Some tabular data" ] .
+
+
+
+gitsha:9a48c2bf7e97a081f2b1ab68eb909bbfc86267be a dldist:Distribution ;
+    dldist:is_distribution_of gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f ;
+    dldist:qualified_part [ a dldist:DistributionPart ;
+            rdf:object "https://concepts.datalad.org/ns/gitsha/e12e9505cff5417f594d719b99720b4c39d86434"^^xsd:anyURI ;
+            dlprops:name "index.html" ],
+        [ a dldist:DistributionPart ;
+            rdf:object "https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv"^^xsd:anyURI ;
+            dlprops:name "table.csv" ] .
+
+
+
+<https://example.org/ns/datasetversion/./archive.zip> a dldist:Distribution ;
+    dldist:has_part <https://example.org/ns/datasetversion/./archive.zip/subdir> ;
+    dldist:qualified_part [ a dldist:DistributionPart ;
+            rdf:object "exthisdsver:./archive.zip/subdir"^^xsd:anyURI ;
+            dlprops:name "subdir" ] .
+
+<https://example.org/ns/datasetversion/./archive.zip/subdir> a dldist:Distribution ;
+    dldist:has_part <https://example.org/ns/datasetversion/./archive.zip/subdir/file.txt> ;
+    dldist:qualified_part [ a dldist:DistributionPart ;
+            rdf:object "exthisdsver:./archive.zip/subdir/file.txt"^^xsd:anyURI ;
+            dlprops:name "file.txt" ] ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:description ;
+            rdfs:value "A subdirectory" ] .
+
+<https://example.org/ns/datasetversion/./archive.zip/subdir/file.txt> a dldist:Distribution ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:description ;
+            rdfs:value "A file" ] .
+
+
+
+<https://example.org/ns/datasetversion/./some/path.ext> a dldist:Distribution ;
+    dldist:license <https://example.org/ns/dataset/#customlicense> ;
+    dlthings:relation <https://example.org/ns/dataset/#customlicense> .
+
+<https://example.org/ns/dataset/#customlicense> a dldist:LicenseDocument ;
+    dldist:license_text "Highly custom terms, never seen before." .
+
+
+
+<https://concepts.datalad.org/ns/annex-key/MD5E-s3214--ba1f2511fc30423bdbb183fe33f3dd0f.csv> a dldist:Distribution ;
+    dldist:byte_size "3214"^^xsd:nonNegativeInteger ;
+    dldist:checksum [ a dlidentifiers:Checksum ;
+            dlidentifiers:creator "spdx:checksumAlgorithm_md5"^^xsd:anyURI ;
+            dlidentifiers:notation "ba1f2511fc30423bdbb183fe33f3dd0f"^^xsd:hexBinary ] ;
+    dldist:media_type "text/csv" .
+
+
 
 gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f a dldist:Resource ;
     dldist:is_version_of <https://concepts.datalad.org/ns/dataset-uuid/cec1da92-0dbd-4df3-8602-7c72b2d12854> ;
@@ -397,6 +311,63 @@ gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f a dldist:Resource ;
     dlthings:relation <https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring>,
         <https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing> .
 
+<https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring> a dlprov:Activity ;
+    skos:exactMatch "obo:NCIT_C25625"^^xsd:anyURI ;
+    dltemporal:ended_at "2001-02-28T18:27:04+02:00"^^w3ctr:NOTE-datetime ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "exthisds:#gituser_doe@example.org"^^xsd:anyURI ;
+            dlroles:roles marcrel:aut ] .
+
+<https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing> a dlprov:Activity ;
+    skos:exactMatch "obo:NCIT_C42882"^^xsd:anyURI ;
+    dltemporal:ended_at "2002-05-30T09:30:10+06:00"^^w3ctr:NOTE-datetime ;
+    dlprov:informed_by <https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring> ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "exthisds:#gituser_doe@example.org"^^xsd:anyURI ;
+            dlroles:roles marcrel:cre ] .
+
+
+
+<https://example.org/ns/datasetversion/./some/path.ext> a dldist:Distribution ;
+    dlco:qualified_access [ a dldist:QualifiedAccess ;
+            dldist:access_service <https://coscine.example.org> ] ;
+    dldist:access_service <https://coscine.example.org> ;
+    dldist:access_url "https://coscine.example.org/coscine"^^xsd:anyURI ;
+    dldist:download_url "https://coscine.example.org/coscine/api/v2/projects/p123/resources/r456/blobs/k789"^^xsd:anyURI,
+        "https://www.example.org/path.ext"^^xsd:anyURI ;
+    dlthings:relation <https://coscine.example.org> .
+
+<https://coscine.example.org> a dldist:DataService ;
+    skos:exactMatch "https://coscine.rwth-aachen.de"^^xsd:anyURI ;
+    dldist:contact_point exthisns:coscine-admin ;
+    dldist:download_url_template "https://coscine.example.org/coscine/api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}" ;
+    dldist:endpoint_description "https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json"^^xsd:anyURI ;
+    dldist:endpoint_url "https://coscine.example.org/coscine"^^xsd:anyURI ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:description ;
+            rdfs:value "Central RDM service at example.org" ] .
+
+
+
+<https://concepts.datalad.org/ns/dataset-uuid/cec1da92-0dbd-4df3-8602-7c72b2d12854> a dldist:Resource ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:identifier ;
+            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate skos:notation ;
+                    rdfs:value "cec1da92-0dbd-4df3-8602-7c72b2d12854" ],
+                [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ADMS:schemaAgency ;
+                    rdfs:value "https://datalad.org" ] ] .
+
+
+
+<https://example.org/ns/datasetversion/#> a dldist:Resource ;
+    dlprov:generated_by <https://example.org/ns/dataset/#study_2005-004406-93> ;
+    dlthings:relation <https://example.org/ns/dataset/#s001>,
+        <https://example.org/ns/dataset/#s002>,
+        <https://example.org/ns/dataset/#study_2005-004406-93> .
+
 <https://example.org/ns/dataset/#s001> a dlprov:Agent ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
             rdf:predicate foaf:name ;
@@ -422,36 +393,213 @@ gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f a dldist:Resource ;
             rdf:object "obo:PATO_0000384"^^xsd:anyURI ;
             rdf:predicate obo:PATO_0000047 ] .
 
-<https://example.org/ns/datasetversion/./archive.zip/subdir> a dldist:Distribution ;
-    dldist:has_part <https://example.org/ns/datasetversion/./archive.zip/subdir/file.txt> ;
-    dldist:qualified_part [ a dldist:DistributionPart ;
-            rdf:object "exthisdsver:./archive.zip/subdir/file.txt"^^xsd:anyURI ;
-            dlprops:name "file.txt" ] ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "A subdirectory" ] .
-
-<https://example.org/ns/datasetversion/./archive.zip/subdir/file.txt> a dldist:Distribution ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "A file" ] .
-
-<https://example.org/ns/datasetversion/./dataset_description.json> a dldist:Distribution ;
-    dldist:media_type "application/json" .
-
-<https://example.org/ns/datasetversion/./participants.tsv> a dldist:Distribution ;
-    dldist:format "http://edamontology.org/format_3475"^^xsd:anyURI .
-
-<https://portal.issn.org/resource/issn/2052-4463> a dlthings:Thing ;
-    skos:exactMatch "bibo:Journal"^^xsd:anyURI ;
+<https://example.org/ns/dataset/#study_2005-004406-93> a dlprov:Activity ;
+    skos:exactMatch "obo:NCIT_C71104"^^xsd:anyURI ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "exthisds:#s002"^^xsd:anyURI ;
+            dlroles:roles obo:NCIT_C142710,
+                obo:NCIT_C173188 ],
+        [ a dlroles:Relationship ;
+            rdf:object "exthisds:#s001"^^xsd:anyURI ;
+            dlroles:roles obo:NCIT_C142710,
+                obo:NCIT_C94342 ] ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
             rdf:predicate ex:title ;
-            rdfs:value "Scientific Data" ] .
+            rdfs:value "Study about the effectiveness of a disease treatment" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ADMS:identifier ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate skos:notation ;
+                    rdfs:value "2005-004406-93" ],
+                [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ADMS:schema_agency ;
+                    rdfs:value "https://eudract.ema.europa.eu" ] ] .
 
-<https://portal.issn.org/resource/issn/2475-9066> a dlthings:Thing ;
+
+
+<https://concepts.datalad.org/ns/annex-uuid/0a8713ca-ef42-11ee-a805-d3e9a774e795> a dldist:DataService ;
+    skos:exactMatch "https://git-annex.branchable.com/special_remotes"^^xsd:anyURI ;
+    dldist:endpoint_description "https://git-annex.branchable.com/special_remotes/webdav/"^^xsd:anyURI ;
+    dldist:endpoint_url "https://dav.box.com/dav/git-annex"^^xsd:anyURI ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:title ;
-            rdfs:value "Journal of Open Source Software" ] .
+            rdf:predicate ex:identifier ;
+            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate skos:notation ;
+                    rdfs:value "0a8713ca-ef42-11ee-a805-d3e9a774e795" ],
+                [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ADMS:schemaAgency ;
+                    rdfs:value "https://git-annex.branchable.com" ] ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate foaf:name ;
+            rdfs:value "box.com" ] .
+
+
+
+[] a dlroles:Relationship ;
+    rdf:object <https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds> ;
+    dlroles:roles <http://purl.obolibrary.org/obo/topic_0003> .
+
+
+
+[] a dlroles:Relationship ;
+    rdf:object <https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds> ;
+    dlroles:roles <http://purl.obolibrary.org/obo/topic_0003> .
+
+
+
+marcrel:this a dlroles:Role .
+
+
+
+marcrel:this a dlroles:Role .
+
+
+
+marcrel:pdr a dlroles:Role ;
+    dlthings:annotations [ a dlthings:Annotation ;
+            dlthings:annotation_tag skos:prefLabel ;
+            dlthings:annotation_value "Project director" ] ;
+    dlthings:description "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager" .
+
+
+
+marcrel:pdr a dlroles:Role ;
+    dlthings:annotations [ a dlthings:Annotation ;
+            dlthings:annotation_tag skos:prefLabel ;
+            dlthings:annotation_value "Project director" ] ;
+    dlthings:description "A person or organization with primary responsibility for all essential aspects of a project, has overall responsibility for managing projects, or provides overall direction to a project manager" .
+
+
+
+[] a dlroles:Relationship ;
+    rdf:object <https://orcid.org/0000-0001-6398-6370> ;
+    dlroles:roles marcrel:aut,
+        marcrel:sad .
+
+
+
+[] a dlroles:Relationship ;
+    rdf:object <https://orcid.org/0000-0001-6398-6370> ;
+    dlroles:roles marcrel:aut,
+        marcrel:sad .
+
+
+
+[] a dlidentifiers:IssuedIdentifier ;
+    dlidentifiers:creator "https://orcid.org"^^xsd:anyURI ;
+    dlidentifiers:notation "0000-0001-6398-6370" ;
+    dlidentifiers:schema_agency "ORCID" .
+
+
+
+[] a dlidentifiers:Checksum ;
+    dlidentifiers:creator "spdx:checksumAlgorithm_md5"^^xsd:anyURI ;
+    dlidentifiers:notation "be32eeadb443c00c3e6ca43f2295e2ee"^^xsd:hexBinary .
+
+
+
+[] a dlidentifiers:DOI ;
+    dlidentifiers:creator "https://op.europa.eu"^^xsd:anyURI ;
+    dlidentifiers:notation "10.2760/271009" ;
+    dlidentifiers:schema_agency "Publications Office of the European Union" .
+
+
+
+[] a dlidentifiers:Identifier ;
+    dlidentifiers:notation "0000-0001-6398-6370" .
+
+
+
+[] a dlidentifiers:Identifier ;
+    dlidentifiers:creator "https://orcid.org"^^xsd:anyURI ;
+    dlidentifiers:notation "0000-0001-6398-6370" .
+
+
+
+[] a dlidentifiers:DOI ;
+    dlidentifiers:creator "https://doi.org"^^xsd:anyURI ;
+    dlidentifiers:notation "10.1038/s41597-022-01163-2" ;
+    dlidentifiers:schema_agency "DOI Foundation" .
+
+
+
+[] a dlidentifiers:IssuedIdentifier ;
+    dlidentifiers:notation "0000-0001-6398-6370" .
+
+
+
+<http://example.org/ns/people/jane> a dlsocial:Person ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "email:jane@example.org"^^xsd:anyURI ;
+            dlroles:roles <http://schema.org/email> ],
+        [ a dlroles:Relationship ;
+            rdf:object "geo:-19.738897,63.453072?z=19"^^xsd:anyURI ;
+            dlroles:roles obo:NCIT_C17556 ] .
+
+
+
+<http://example.org/projects/p1a> a dlsocial:Project ;
+    dlprops:description "A project about approaching a new field, and not looking entirely incompetent after some time." ;
+    dlprops:short_name "BANG!" ;
+    dlprops:title "Impactful entry" ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate <http://example.org/ns/psych/self-esteem-boost-potential> ;
+            rdfs:range "linkml:int"^^xsd:anyURI ;
+            rdfs:value "100" ] .
+
+
+
+<http://example.org/projects/p1a> a dlsocial:Project ;
+    dlprov:associated_with <http://orcid.org/0000-0001-6398-6370> ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "http://orcid.org/0000-0001-6398-6370"^^xsd:anyURI ;
+            dlroles:roles marcrel:ctb ] ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object "ex:projects/grand-plan"^^xsd:anyURI ;
+            rdf:predicate ex:isPartOf ] .
+
+
+
+<https://orcid.org/0000-0001-6398-6370> a dlsocial:Person ;
+    dlprov:acted_on_behalf_of <https://ror.org/02nv7yv05> ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate <http://www.bioassayontology.org/bao#BAO_0002826> ;
+            rdfs:value "1" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate foaf:name ;
+            rdfs:value "Michael Hanke" ] .
+
+
+
+<http://example.org/projects/p1a> a dlsocial:Project .
+
+
+
+<https://trr379.de> a dlsocial:Organization ;
+    dlroles:qualified_relations [ a dlroles:Relationship ;
+            rdf:object "https://ror.org/018mejw64"^^xsd:anyURI ;
+            dlroles:roles marcrel:fnd ] .
+
+
+
+<http://orcid.org/0000-0001-7628-0801> a dlsocial:Person .
+
+
+
+<http://example.org/ns/zorro> a dlsocial:Person ;
+    dlsocial:additional_names "Zorro" ;
+    dlsocial:family_name "de la Vega" ;
+    dlsocial:formatted_name "Don Diego Zorro de la Vega III" ;
+    dlsocial:given_name "Diego" ;
+    dlsocial:honorific_name_prefix "Don" ;
+    dlsocial:honorific_name_suffix "III" .
+
+
+
+<https://ror.org/018mejw64> a dlsocial:Organization .
+
+
 
 <https://ror.org/018mejw64> a dlsocial:Organization ;
     dltemporal:at_location <https://geonames.org/2946447> ;
@@ -463,6 +611,73 @@ gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f a dldist:Resource ;
             dlidentifiers:notation "501100001659" ] ;
     dlprops:name "Deutsche Forschungsgemeinschaft" ;
     dlprops:short_name "DFG" .
+
+
+
+<https://doi.org/10.21105/joss.03262> a dlthings:Thing ;
+    dlthings:relation <https://portal.issn.org/resource/issn/2475-9066>,
+        <https://www.scicrunch.org/resolver/SCR_003931> .
+
+<https://portal.issn.org/resource/issn/2475-9066> a dlthings:Thing ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "Journal of Open Source Software" ] .
+
+<https://www.scicrunch.org/resolver/SCR_003931> a dlthings:Thing .
+
+
+
+exthisns:measurement853 a dlthings:ValueSpecification ;
+    rdfs:range xsd:decimal ;
+    rdfs:value "145.3" ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "measured mass (kg)" ] ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object obo:PATO_0000125 ;
+            rdf:predicate ex:subject ],
+        [ a dlthings:Statement ;
+            rdf:object obo:UO_0000009 ;
+            rdf:predicate obo:UO_0000000 ],
+        [ a dlthings:Statement ;
+            rdf:object obo:IAO_0000109 ;
+            rdf:predicate ex:subject ] .
+
+
+
+exthisns:measurement853 a dlthings:ValueSpecification ;
+    rdfs:range xsd:decimal ;
+    rdfs:value "145.3" ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "measured mass (kg)" ] ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object obo:PATO_0000125 ;
+            rdf:predicate ex:subject ],
+        [ a dlthings:Statement ;
+            rdf:object obo:UO_0000009 ;
+            rdf:predicate obo:UO_0000000 ],
+        [ a dlthings:Statement ;
+            rdf:object obo:IAO_0000109 ;
+            rdf:predicate ex:subject ] .
+
+
+
+ex:modified a dlthings:Property ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "modified" ] ;
+    dlthings:description "Date on which the resource was changed." .
+
+
+
+ex:modified a dlthings:Property ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "modified" ] ;
+    dlthings:description "Date on which the resource was changed." .
+
+
 
 <https://ror.org/02nv7yv05> a dlthings:Thing ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
@@ -488,101 +703,114 @@ gitsha:8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f a dldist:Resource ;
             rdf:object "https://en.wikipedia.org/wiki/Forschungszentrum_J%C3%BClich"^^xsd:anyURI ;
             rdf:predicate owl:sameAs ] .
 
-<https://www.scicrunch.org/resolver/SCR_003931> a dlthings:Thing .
 
-<https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring> a dlprov:Activity ;
-    skos:exactMatch "obo:NCIT_C25625"^^xsd:anyURI ;
-    dltemporal:ended_at "2001-02-28T18:27:04+02:00"^^w3ctr:NOTE-datetime ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "exthisds:#gituser_doe@example.org"^^xsd:anyURI ;
-            dlroles:roles marcrel:aut ] .
 
-<https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#committing> a dlprov:Activity ;
-    skos:exactMatch "obo:NCIT_C42882"^^xsd:anyURI ;
-    dltemporal:ended_at "2002-05-30T09:30:10+06:00"^^w3ctr:NOTE-datetime ;
-    dlprov:informed_by <https://concepts.datalad.org/ns/gitsha/8d6f033bb2a6109b2c4d64d6f27b0feb181e4d0f#authoring> ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "exthisds:#gituser_doe@example.org"^^xsd:anyURI ;
-            dlroles:roles marcrel:cre ] .
+exthisns:measurement853 a dlthings:ValueSpecification ;
+    rdfs:value "special" .
 
-<https://example.org/ns/dataset/#> a dldist:Resource ;
+
+
+exthisns:measurement853 a dlthings:ValueSpecification ;
+    rdfs:value "special" .
+
+
+
+[] a dlthings:Statement ;
+    rdf:object <https://helmholtz.de> ;
+    rdf:predicate ex:subject .
+
+
+
+[] a dlthings:Statement ;
+    rdf:object <https://helmholtz.de> ;
+    rdf:predicate ex:subject .
+
+
+
+<https://doi.org/10.1038/s41597-022-01163-2> a dlthings:Thing ;
+    skos:exactMatch "bibo:AcademicArticle"^^xsd:anyURI ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate bibo:number ;
+            rdfs:value "80" ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ex:title ;
+                    rdfs:value "Document number" ] ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate bibo:doi ;
+            rdfs:value "https://doi.org/10.1038/s41597-022-01163-2" ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ex:title ;
+                    rdfs:value "DOI" ] ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:identifier ;
+            skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ADMS:schemaAgency ;
+                    rdfs:value "https://doi.org" ],
+                [ a dlthings:AttributeSpecification ;
+                    rdf:predicate skos:notation ;
+                    rdfs:value "10.1038/s41597-022-01163-2" ] ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:modified ;
+            rdfs:range "xsd:date"^^xsd:anyURI ;
+            rdfs:value "2022-02-11" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate bibo:volume ;
+            rdfs:value "9" ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ex:title ;
+                    rdfs:value "Volume" ] ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:date ;
+            rdfs:range "xsd:date"^^xsd:anyURI ;
+            rdfs:value "2022-03-11" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:bibliographicCitation ;
+            rdfs:value "Wagner, A.S., Waite, L.K., Wierzba, M. et al. FAIRly big: A framework for computationally reproducible processing of large-scale data. Sci Data 9, 80 (2022)." ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate ex:title ;
+            rdfs:value "FAIRly big: A framework for computationally reproducible processing of large-scale data" ],
+        [ a dlthings:AttributeSpecification ;
             rdf:predicate ex:description ;
-            rdfs:value "A collection of some data" ] .
+            rdfs:value "Large-scale datasets present unique opportunities to perform scientific investigations with unprecedented breadth. However, they also pose considerable challenges for the findability, accessibility, interoperability, and reusability (FAIR) of research outcomes due to infrastructure limitations, data usage constraints, or software license restrictions. Here we introduce a DataLad-based, domain-agnostic framework suitable for reproducible data processing in compliance with open science mandates. The framework attempts to minimize platform idiosyncrasies and performance-related complexities. It affords the capture of machine-actionable computational provenance records that can be used to retrace and verify the origins of research outcomes, as well as be re-executed independent of the original computing infrastructure. We demonstrate the framework’s performance using two showcases: one highlighting data sharing and transparency (using the studyforrest.org dataset) and another highlighting scalability (using the largest public brain imaging dataset available: the UK Biobank dataset)." ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate bibo:numPages ;
+            rdfs:range "xsd:nonNegativeInteger"^^xsd:anyURI ;
+            rdfs:value "17" ;
+            dlthings:attributes [ a dlthings:AttributeSpecification ;
+                    rdf:predicate ex:title ;
+                    rdfs:value "Number of pages" ] ] ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object "https://www.nature.com/subjects/software"^^xsd:anyURI ;
+            rdf:predicate ex:subject ],
+        [ a dlthings:Statement ;
+            rdf:object "https://www.nature.com/subjects/data-publication-and-archiving"^^xsd:anyURI ;
+            rdf:predicate ex:subject ],
+        [ a dlthings:Statement ;
+            rdf:object "https://portal.issn.org/resource/issn/2052-4463"^^xsd:anyURI ;
+            rdf:predicate ex:isPartOf ],
+        [ a dlthings:Statement ;
+            rdf:object "https://www.nature.com/subjects/data-processing"^^xsd:anyURI ;
+            rdf:predicate ex:subject ],
+        [ a dlthings:Statement ;
+            rdf:object "https://spdx.org/licenses/CC-BY-4.0"^^xsd:anyURI ;
+            rdf:predicate ex:license ],
+        [ a dlthings:Statement ;
+            rdf:object "https://www.nature.com/articles/s41597-022-01163-2"^^xsd:anyURI ;
+            rdf:predicate owl:sameAs ] ;
+    dlthings:relation <https://portal.issn.org/resource/issn/2052-4463> .
 
-<https://example.org/ns/dataset/#customlicense> a dldist:LicenseDocument ;
-    dldist:license_text "Highly custom terms, never seen before." .
-
-<https://example.org/ns/dataset/#study_2005-004406-93> a dlprov:Activity ;
-    skos:exactMatch "obo:NCIT_C71104"^^xsd:anyURI ;
-    dlroles:qualified_relations [ a dlroles:Relationship ;
-            rdf:object "exthisds:#s002"^^xsd:anyURI ;
-            dlroles:roles obo:NCIT_C142710,
-                obo:NCIT_C173188 ],
-        [ a dlroles:Relationship ;
-            rdf:object "exthisds:#s001"^^xsd:anyURI ;
-            dlroles:roles obo:NCIT_C142710,
-                obo:NCIT_C94342 ] ;
+<https://portal.issn.org/resource/issn/2052-4463> a dlthings:Thing ;
+    skos:exactMatch "bibo:Journal"^^xsd:anyURI ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
             rdf:predicate ex:title ;
-            rdfs:value "Study about the effectiveness of a disease treatment" ],
-        [ a dlthings:AttributeSpecification ;
-            rdf:predicate ADMS:identifier ;
-            dlthings:attributes [ a dlthings:AttributeSpecification ;
-                    rdf:predicate skos:notation ;
-                    rdfs:value "2005-004406-93" ],
-                [ a dlthings:AttributeSpecification ;
-                    rdf:predicate ADMS:schema_agency ;
-                    rdfs:value "https://eudract.ema.europa.eu" ] ] .
+            rdfs:value "Scientific Data" ] .
 
-<https://example.org/ns/datasetversion/#> a dldist:Resource ;
-    dldist:is_version_of <https://example.org/ns/dataset/#> ;
-    dlprov:generated_by <https://example.org/ns/dataset/#study_2005-004406-93> ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "A version of a collection of some data\"" ] ;
-    dlthings:relation <https://example.org/ns/dataset/#s001>,
-        <https://example.org/ns/dataset/#s002>,
-        <https://example.org/ns/dataset/#study_2005-004406-93> .
 
-<https://example.org/ns/datasetversion/#some/path> a dldist:Resource ;
-    dldist:is_part_of <https://example.org/ns/datasetversion/#> ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "Some tabular data" ] .
-
-<https://coscine.example.org> a dldist:DataService ;
-    skos:exactMatch "https://coscine.rwth-aachen.de"^^xsd:anyURI ;
-    dldist:contact_point exthisns:coscine-admin ;
-    dldist:download_url_template "https://coscine.example.org/coscine/api/v2/projects/{projectId}/resources/{resourceId}/blobs/{key}" ;
-    dldist:endpoint_description "https://coscine.rwth-aachen.de/coscine/api/swagger/v2/swagger.json"^^xsd:anyURI ;
-    dldist:endpoint_url "https://coscine.example.org/coscine"^^xsd:anyURI ;
-    dlthings:attributes [ a dlthings:AttributeSpecification ;
-            rdf:predicate ex:description ;
-            rdfs:value "Central RDM service at example.org" ] .
-
-ex:title a dlthings:Property .
-
-[] a dlroles:Relationship ;
-    rdf:object "https://orcid.org/0000-0001-6398-6370"^^xsd:anyURI ;
-    dlroles:roles marcrel:aut,
-        marcrel:sad .
-
-[] a dlroles:Relationship ;
-    rdf:object "https://en.wikipedia.org/wiki/Vulcan_(Star_Trek)#Mind_melds"^^xsd:anyURI ;
-    dlroles:roles obo:topic_0003 .
-
-[] a dlidentifiers:Identifier ;
-    dlidentifiers:creator "https://orcid.org"^^xsd:anyURI ;
-    dlidentifiers:notation "0000-0001-6398-6370" .
-
-[] a dlidentifiers:Checksum ;
-    dlidentifiers:creator "spdx:checksumAlgorithm_md5"^^xsd:anyURI ;
-    dlidentifiers:notation "be32eeadb443c00c3e6ca43f2295e2ee"^^xsd:hexBinary .
 
 [] a dlthings:AttributeSpecification ;
     rdf:predicate ex:identifier ;
-    skos:exactMatch "ADMS:Identifier"^^xsd:anyURI ;
+    skos:exactMatch ADMS:Identifier ;
     dlthings:attributes [ a dlthings:AttributeSpecification ;
             rdf:predicate ADMS:schemaAgency ;
             rdfs:value "https://d-nb.info" ],
@@ -590,32 +818,55 @@ ex:title a dlthings:Property .
             rdf:predicate skos:notation ;
             rdfs:value "5008462-8" ] .
 
-[] a dlthings:Statement ;
-    rdf:object "https://helmholtz.de"^^xsd:anyURI ;
-    rdf:predicate ex:subject .
+
+
+[] a dlthings:AttributeSpecification ;
+    rdf:predicate ex:identifier ;
+    skos:exactMatch ADMS:Identifier ;
+    dlthings:attributes [ a dlthings:AttributeSpecification ;
+            rdf:predicate ADMS:schemaAgency ;
+            rdfs:value "https://d-nb.info" ],
+        [ a dlthings:AttributeSpecification ;
+            rdf:predicate skos:notation ;
+            rdfs:value "5008462-8" ] .
+
+
+
+ex:title a dlthings:Property .
+
+
+
+ex:title a dlthings:Property .
+
+
 
 [] a dlthings:AttributeSpecification ;
     rdf:predicate ex:title ;
     rdfs:value "My attribute" .
 
-[] a dlidentifiers:IssuedIdentifier ;
-    dlidentifiers:notation "0000-0001-6398-6370" .
 
-[] a dlidentifiers:DOI ;
-    dlidentifiers:creator "https://op.europa.eu"^^xsd:anyURI ;
-    dlidentifiers:notation "10.2760/271009" ;
-    dlidentifiers:schema_agency "Publications Office of the European Union" .
 
-[] a dlidentifiers:IssuedIdentifier ;
-    dlidentifiers:creator "https://orcid.org"^^xsd:anyURI ;
-    dlidentifiers:notation "0000-0001-6398-6370" ;
-    dlidentifiers:schema_agency "ORCID" .
+[] a dlthings:AttributeSpecification ;
+    rdf:predicate ex:title ;
+    rdfs:value "My attribute" .
 
-[] a dlidentifiers:DOI ;
-    dlidentifiers:creator "https://doi.org"^^xsd:anyURI ;
-    dlidentifiers:notation "10.1038/s41597-022-01163-2" ;
-    dlidentifiers:schema_agency "DOI Foundation" .
 
-[] a dlidentifiers:Identifier ;
-    dlidentifiers:notation "0000-0001-6398-6370" .
+
+<https://doi.org/10.21105/joss.03262> a dlthings:Thing ;
+    dlthings:characterized_by [ a dlthings:Statement ;
+            rdf:object "https://www.scicrunch.org/resolver/SCR_003931"^^xsd:anyURI ;
+            rdf:predicate ex:subject ] .
+
+
+
+exthisns:mything a dlthings:Thing .
+
+
+
+exthisns:mything a dlthings:Thing .
+
+
+
+<http://dbpedia.org/resource/Madrid> a dlspatial:Location .
+
 

--- a/public/dlschemas_owl.ttl
+++ b/public/dlschemas_owl.ttl
@@ -1,5 +1,9 @@
+@prefix ADMS: <http://www.w3.org/ns/adms#> .
 @prefix IAO: <http://purl.obolibrary.org/obo/IAO_> .
+@prefix bibo: <http://purl.org/ontology/bibo/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dledist: <https://concepts.datalad.org/s/edistributions/unreleased/> .
 @prefix dlidentifiers: <https://concepts.datalad.org/s/identifiers/unreleased/> .
 @prefix dlprops: <https://concepts.datalad.org/s/properties/unreleased/> .
 @prefix dlprov: <https://concepts.datalad.org/s/prov/unreleased/> .
@@ -11,39 +15,42 @@
 @prefix dltemporal: <https://concepts.datalad.org/s/temporal/unreleased/> .
 @prefix dlthings: <https://concepts.datalad.org/s/things/v1/> .
 @prefix dltypes: <https://concepts.datalad.org/s/types/unreleased/> .
-@prefix ns1: <http://purl.org/ontology/bibo/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix inm7base: <https://concepts.inm7.de/s/base/unreleased/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix pav: <http://purl.org/pav/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix schema1: <http://schema.org/> .
-@prefix sio: <http://semanticscience.org/resource/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix trr379base: <https://concepts.trr379.de/s/base/unreleased/> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
 @prefix w3ctr: <https://www.w3.org/TR/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-xsd:nonNegativeInteger a rdfs:Datatype .
+dledist:compression_format a owl:ObjectProperty ;
+    rdfs:label "compression_format" ;
+    rdfs:range dlthings:Thing ;
+    skos:definition "The compression format of the distribution in which the data is contained in a compressed form, e.g., to reduce the size of the downloadable file." ;
+    skos:exactMatch dcat:compressFormat ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
 
-dlprops:conforms_to a owl:DatatypeProperty ;
-    rdfs:label "conforms_to" ;
-    rdfs:range xsd:anyURI ;
-    skos:definition "An established standard to which the subject conforms." ;
-    skos:exactMatch <dcterms:conformsTo> ;
-    skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> ;
-    skos:note "This property SHOULD be used to indicate a model, schema, ontology, view or profile that the subject conforms to." .
+dledist:packaging_format a owl:ObjectProperty ;
+    rdfs:label "packaging_format" ;
+    rdfs:range dlthings:Thing ;
+    skos:definition "The package format of the distribution in which one or more data files are grouped together, e.g., to enable a set of related files to be downloaded together." ;
+    skos:exactMatch dcat:packageFormat ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
 
 dltypes:EmailAddress a rdfs:Datatype ;
     owl:equivalentClass [ a rdfs:Datatype ;
             owl:onDatatype xsd:string ;
             owl:withRestrictions ( [ xsd:pattern "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])" ] ) ] .
 
-<https://concepts.trr379.de/s/base/unreleased.owl.ttl> a owl:Ontology ;
-    rdfs:label "trr379-base-schema" ;
+<https://concepts.inm7.de/s/base/unreleased.owl.ttl> a owl:Ontology ;
+    rdfs:label "inm7-base-schema" ;
     dcterms:license "CC-BY-4.0" ;
-    dcterms:title "Base schema for TRR379 metadata" ;
-    ns1:status <http://publications.europa.eu/resource/authority/concept-status/DRAFT> ;
+    dcterms:title "INM7 base metadata model" ;
+    bibo:status <http://publications.europa.eu/resource/authority/concept-status/DRAFT> ;
     pav:version "UNRELEASED" ;
     skos:definition """TODO
 
@@ -51,10 +58,9 @@ More information is available on the schema's [about page](about).
 
 The schema definition is available as
 
-- [JSON-LD context](../unreleased.context.jsonld)
+- [JSON-LD context](../unreleased.jsonld)
 - [LinkML YAML](../unreleased.yaml)
 - [OWL TTL](../unreleased.owl.ttl)
-- [SHACL TTL](../unreleased.shacl.ttl)
 """ ;
     skos:note "ALL CONTENT HERE IS UNRELEASED AND MAY CHANGE ANY TIME" .
 
@@ -63,12 +69,39 @@ xsd:hexBinary a rdfs:Datatype ;
             owl:onDatatype xsd:string ;
             owl:withRestrictions ( [ xsd:pattern "^[a-fA-F0-9]+$" ] ) ] .
 
-dlprops:about a owl:DatatypeProperty ;
-    rdfs:label "about" ;
+xsd:nonNegativeInteger a rdfs:Datatype .
+
+dledist:checksums a owl:ObjectProperty ;
+    rdfs:label "checksums" ;
+    rdfs:range dlidentifiers:Checksum ;
+    skos:definition "The checksum property provides a mechanism that can be used to verify that the contents of a file or package have not changed." ;
+    skos:exactMatch <spdx:checksum> ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:download_urls a owl:DatatypeProperty ;
+    rdfs:label "download_urls" ;
     rdfs:range xsd:anyURI ;
+    skos:definition "URL that gives direct access to the subject in the form of a downloadable file in a given format." ;
+    skos:exactMatch dcat:downloadURL ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> ;
+    skos:relatedMatch dcat:accessURL,
+        dcat:landingPage .
+
+dlprops:about a owl:ObjectProperty ;
+    rdfs:label "about" ;
+    rdfs:range dlthings:Thing ;
     skos:definition "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
     skos:exactMatch IAO:0000136,
-        schema1:about ;
+        <schema:about> ;
+    skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> .
+
+dlprops:keywords a owl:DatatypeProperty ;
+    rdfs:label "keywords" ;
+    rdfs:range xsd:string ;
+    skos:definition "One or more keywords or tags describing the subject." ;
+    skos:exactMatch IAO:0000629,
+        dcat:keyword,
+        <schema:keywords> ;
     skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> .
 
 dlprov:acted_on_behalf_of a owl:ObjectProperty ;
@@ -121,25 +154,7 @@ dlprov:informed_by a owl:ObjectProperty ;
 
 dlres:IndexedResourcePart a owl:Class ;
     rdfs:label "IndexedResourcePart" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty trr379base:resource ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:locator ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty trr379base:locator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:locator ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:resource ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty trr379base:resource ],
-        dlres:IndexedResourceRelationship ;
+    rdfs:subClassOf dlres:IndexedResourceRelationship ;
     skos:definition "An association class for attaching an index `locator` as additional information to a `hasPart` relationship." ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
@@ -149,104 +164,54 @@ dlres:IndexedResourcePartOf a owl:Class ;
     skos:definition "An association class for attaching an index `locator` as additional information to a `isPartOf` relationship." ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
-dlres:IndexedResourceRelationship a owl:Class ;
-    rdfs:label "IndexedResourceRelationship" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlres:locator ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlres:locator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlres:resource ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlres:locator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlroles:roles ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlres:Resource ;
-            owl:onProperty dlres:resource ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlres:resource ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlroles:Role ;
-            owl:onProperty dlroles:roles ] ;
-    skos:definition "An association class for attaching a `name` as additional information to a `hasPart` relationship." ;
+dlres:access_methods a owl:ObjectProperty ;
+    rdfs:label "access_methods" ;
+    rdfs:range dlres:AccessMethod ;
+    skos:definition "(Alternative) means to gain access to the subject." ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
-dlres:indexed_part_of a owl:ObjectProperty ;
-    rdfs:label "indexed_part_of" ;
-    rdfs:range dlres:IndexedResourcePartOf ;
-    skos:broadMatch <dcat:qualifiedRelation> ;
-    skos:definition "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
+dlres:version_notes a owl:DatatypeProperty ;
+    rdfs:label "version_notes" ;
+    rdfs:range xsd:string ;
+    skos:definition "A description of changes between this version and the previous version of the subject." ;
+    skos:exactMatch ADMS:versionNotes ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
-dlres:indexed_parts a owl:ObjectProperty ;
-    rdfs:label "indexed_parts" ;
-    rdfs:range dlres:IndexedResourcePart ;
-    skos:broadMatch <dcat:qualifiedRelation> ;
-    skos:definition "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+dlroles:roles a owl:ObjectProperty ;
+    rdfs:label "roles" ;
+    rdfs:range dlroles:Role ;
+    skos:definition "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
+    skos:exactMatch dcat:had_role,
+        <prov:hadRole> ;
+    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
 
 dlsocial:additional_names a owl:DatatypeProperty ;
     rdfs:label "additional_names" ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "Additional name(s) associated with the subject, such as one or more middle names, or a nick name." ;
-    skos:exactMatch <vcard:additional_name> ;
+    skos:exactMatch vcard:additional_name ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
-
-dltemporal:InstantaneousEvent a owl:Class ;
-    rdfs:label "InstantaneousEvent" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom dlidentifiers:Identifier ;
-            owl:onProperty dlidentifiers:identifiers ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dltemporal:at_time ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlroles:qualified_relations ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dltemporal:at_time ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlroles:Relationship ;
-            owl:onProperty dlroles:qualified_relations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlidentifiers:identifiers ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom w3ctr:NOTE-datetime ;
-            owl:onProperty dltemporal:at_time ],
-        dlthings:Thing ;
-    skos:definition "A moment of a transition from one particular state of the world to another." ;
-    skos:exactMatch <prov:InstantaneousEvent> ;
-    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
 
 dlthings:Annotation a owl:Class ;
     rdfs:label "Annotation" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlthings:annotation_tag ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:annotation_tag ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlthings:annotation_value ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:annotation_value ],
+        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlthings:annotation_tag ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty dlthings:annotation_value ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:annotation_tag ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:annotation_value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:annotation_tag ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
             owl:onProperty dlthings:annotation_value ] ;
     skos:definition "A tag/value pair with the semantics of OWL Annotation." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
@@ -254,14 +219,14 @@ dlthings:Annotation a owl:Class ;
 dlthings:ValueSpecification a owl:Class ;
     rdfs:label "ValueSpecification" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty trr379base:value ],
-        [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:value ],
+            owl:onProperty inm7base:value ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty trr379base:value ],
+            owl:onProperty inm7base:value ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:value ],
         dlthings:Thing,
         dlthings:ValueSpecificationMixin ;
     skos:definition "A `Thing` that is a value of some kind. This class can be used to describe an outcome of a measurement, a factual value or constant, or other qualitative or quantitative information with an associated identifier. If no identifier is available, an `AttributeSpecification` can be used within the context of an associated `Thing` (`attributes`)." ;
@@ -271,23 +236,23 @@ dlthings:ValueSpecification a owl:Class ;
 dlthings:ValueSpecificationMixin a owl:Class ;
     rdfs:label "ValueSpecificationMixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:range ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dlthings:range ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlthings:value ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlthings:value ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:range ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlthings:range ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlthings:value ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:range ] ;
+            owl:onProperty dlthings:value ] ;
     skos:definition "Mix-in for a (structured) value specification. Two slots are provided to define a (literal) value (`value`) and its type (`range`)." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
@@ -295,13 +260,14 @@ dlthings:annotations a owl:ObjectProperty ;
     rdfs:label "annotations" ;
     rdfs:range dlthings:Annotation ;
     skos:definition "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+    skos:exactMatch obo:NCIT_C44272 ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
 dlthings:attributes a owl:ObjectProperty ;
     rdfs:label "attributes" ;
     rdfs:range dlthings:AttributeSpecification ;
     skos:definition "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-    skos:exactMatch sio:SIO_000008 ;
+    skos:exactMatch <sio:SIO_000008> ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
 dlthings:broad_mappings a owl:DatatypeProperty ;
@@ -352,68 +318,123 @@ dlthings:relations a owl:ObjectProperty,
     rdfs:domain dlthings:Thing ;
     rdfs:range dlthings:Thing ;
     skos:definition "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-    skos:exactMatch <dcat:relation>,
-        <dcterms:relation> ;
+    skos:exactMatch <dcterms:relation>,
+        dcat:relation ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
-rdfs:Resource a rdfs:Datatype ;
-    owl:equivalentClass xsd:anyURI .
-
-dlidentifiers:Checksum a owl:Class ;
-    rdfs:label "Checksum" ;
+dledist:AccessThroughLandingPage a owl:Class ;
+    rdfs:label "AccessThroughLandingPage" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:creator ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:hexBinary ;
-            owl:onProperty trr379base:notation ],
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dledist:landing_page ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty trr379base:creator ],
+            owl:onProperty dledist:landing_page ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:landing_page ],
+        dlres:AccessMethod ;
+    skos:definition "Access to the subject through a web page, or information on a web page, that can be navigated to in a Web browser." ;
+    skos:exactMatch dledist:AccessThroughLandingPage ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:DataServiceAccess a owl:Class ;
+    rdfs:label "DataServiceAccess" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dledist:data_service ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
-            owl:onProperty trr379base:creator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty trr379base:notation ],
+            owl:onProperty dledist:data_service ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty trr379base:notation ],
-        dlidentifiers:ComputedIdentifier ;
-    skos:definition "A Checksum is a value that allows to check the integrity of the contents of a file. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented." ;
-    skos:exactMatch dlidentifiers:Checksum,
-        <spdx:Checksum> ;
-    skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dledist:DataService ;
+            owl:onProperty dledist:data_service ],
+        dlres:AccessMethod ;
+    skos:definition "Access through a data service where the subject is available via a particular locator." ;
+    skos:exactMatch dledist:DataServiceAccess ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:DirectDownload a owl:Class ;
+    rdfs:label "DirectDownload" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:download_urls ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dledist:download_urls ],
+        dlres:AccessMethod ;
+    skos:definition "Direct access to the subject is possible via a download URL." ;
+    skos:exactMatch dledist:DirectDownload ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:byte_size a owl:DatatypeProperty ;
+    rdfs:label "byte_size" ;
+    rdfs:range xsd:nonNegativeInteger ;
+    skos:definition "The size of the subject in bytes." ;
+    skos:exactMatch dcat:byteSize ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:data_service a owl:ObjectProperty ;
+    rdfs:label "data_service" ;
+    rdfs:range dledist:DataService ;
+    skos:definition "A data service that gives access to the distribution of a dataset." ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:landing_page a owl:DatatypeProperty ;
+    rdfs:label "landing_page" ;
+    rdfs:range xsd:anyURI ;
+    skos:definition "A Web page that can be navigated to in a Web browser to gain access to a resource." ;
+    skos:exactMatch dcat:landingPage,
+        foaf:page ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:media_type a owl:DatatypeProperty ;
+    rdfs:label "media_type" ;
+    rdfs:range xsd:string ;
+    rdfs:seeAlso <https://www.iana.org/assignments/media-types> ;
+    rdfs:subPropertyOf dledist:format ;
+    skos:definition "The media type of a distribution as defined by IANA" ;
+    skos:exactMatch dcat:mediaType ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
 
 dlidentifiers:DOI a owl:Class ;
     rdfs:label "DOI" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:notation ],
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:schema_agency ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty trr379base:creator ],
+            owl:onProperty inm7base:notation ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty trr379base:notation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty trr379base:creator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:schema_agency ],
+            owl:onProperty inm7base:creator ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:creator ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:notation ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty trr379base:schema_agency ],
+            owl:onProperty inm7base:creator ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:schema_agency ],
+            owl:onProperty inm7base:schema_agency ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:schema_agency ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:notation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:notation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:creator ],
         dlidentifiers:IssuedIdentifier ;
     owl:hasKey ( dlidentifiers:notation ) ;
     skos:definition "Digital Object Identifier (DOI; ISO 26324), an identifier system governed by the DOI Foundation, where individual identifiers are issued by one of several registration agencies." ;
@@ -424,6 +445,7 @@ dlidentifiers:creator a owl:DatatypeProperty ;
     rdfs:label "creator" ;
     rdfs:range xsd:anyURI ;
     skos:definition "An agent responsible for making an entity." ;
+    skos:editorialNote "The `range` is only `uriorcurie` here (and not `Thing`), because we have an `ifabsent` declaration for DOIs that only work with this type. And even for that it needs a patch." ;
     skos:exactMatch <dcterms:creator> ;
     skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
 
@@ -431,15 +453,23 @@ dlidentifiers:schema_agency a owl:DatatypeProperty ;
     rdfs:label "schema_agency" ;
     rdfs:range xsd:string ;
     skos:definition "Name of the agency that issued an identifier." ;
-    skos:exactMatch <ADMS:schemaAgency> ;
+    skos:exactMatch ADMS:schemaAgency ;
     skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
 
-dlprops:same_as a owl:DatatypeProperty ;
+dlprops:conforms_to a owl:ObjectProperty ;
+    rdfs:label "conforms_to" ;
+    rdfs:range dlthings:Thing ;
+    skos:definition "An established standard to which the subject conforms." ;
+    skos:exactMatch <dcterms:conformsTo> ;
+    skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> ;
+    skos:note "This property SHOULD be used to indicate a model, schema, ontology, view or profile that the subject conforms to." .
+
+dlprops:same_as a owl:ObjectProperty ;
     rdfs:label "same_as" ;
-    rdfs:range xsd:anyURI ;
-    skos:closeMatch schema1:sameAs ;
+    rdfs:range dlthings:Thing ;
+    skos:closeMatch <schema:sameAs> ;
     skos:definition "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-    skos:exactMatch owl:sameAs ;
+    skos:exactMatch <owl:sameAs> ;
     skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> .
 
 dlprov:SoftwareAgent a owl:Class ;
@@ -453,25 +483,25 @@ dlprov:SoftwareAgent a owl:Class ;
 dlpubs:Publication a owl:Class ;
     rdfs:label "Publication" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom w3ctr:NOTE-datetime ;
-            owl:onProperty dltemporal:date_published ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dltemporal:date_modified ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty dltemporal:date_published ],
         [ a owl:Restriction ;
             owl:allValuesFrom w3ctr:NOTE-datetime ;
             owl:onProperty dltemporal:date_modified ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dltemporal:date_published ],
+            owl:onProperty dltemporal:date_modified ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dltemporal:date_modified ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:date_published ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:date_published ],
         dlres:Resource ;
-    skos:closeMatch sio:SIO_000087 ;
+    skos:closeMatch <sio:SIO_000087> ;
     skos:definition "A document that is the output of a publishing process. This can printed or electronic work offered for distribution, and may have been made available by a publisher." ;
     skos:exactMatch IAO:0000311,
         obo:NCIT_C48471,
@@ -480,10 +510,31 @@ dlpubs:Publication a owl:Class ;
 
 dlres:Dataset a owl:Class ;
     rdfs:label "Dataset" ;
-    rdfs:subClassOf dlres:Resource ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Distribution ;
+            owl:onProperty dlres:distributions ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:distributions ],
+        dlres:Resource ;
     skos:definition "A collection of data, published or curated by a single agent. This is a conceptual entity. A single dataset might be available in more than one representation, with differing schematic layouts, formats, and serializations." ;
-    skos:exactMatch <dcat:Dataset>,
+    skos:exactMatch dcat:Dataset,
         dlres:Dataset ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+
+dlres:Document a owl:Class ;
+    rdfs:label "Document" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:distributions ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Distribution ;
+            owl:onProperty dlres:distributions ],
+        dlres:Resource ;
+    skos:definition "A conceptual entity representing things which a, broadly conceived, \"documents. This includes non-textual things like images. A conceputal document is to be distinguished from its physical, or electronic distributions." ;
+    skos:editorialNote "The key difference between a dataset and a document is the collection-nature of the dataset (multiple items of a kind in a collection), whereas a document is \"one of its kind\". A dataset could comprise multiple documents." ;
+    skos:exactMatch foaf:Document,
+        dlres:Document ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
 dlres:Grant a owl:Class ;
@@ -498,9 +549,10 @@ dlres:Grant a owl:Class ;
             owl:allValuesFrom dlprov:Agent ;
             owl:onProperty dlres:sponsor ],
         dlres:Resource ;
-    skos:definition "A grant, typically financial or otherwise quantifiable, of resources." ;
-    skos:exactMatch schema1:Grant,
-        dlres:Grant ;
+    skos:definition "A grant, typically financial or otherwise quantifiable, resources." ;
+    skos:editorialNote "A grant is not a document. The associated document would be the grant agreement." ;
+    skos:exactMatch dlres:Grant,
+        <schema:Grant> ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
 dlres:Instrument a owl:Class ;
@@ -510,51 +562,77 @@ dlres:Instrument a owl:Class ;
     skos:exactMatch dlres:Instrument ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> ;
     skos:narrowMatch obo:NCIT_C62103 ;
-    skos:relatedMatch schema1:instrument .
+    skos:relatedMatch <schema:instrument> .
 
-dlres:locator a owl:DatatypeProperty ;
-    rdfs:label "locator" ;
-    rdfs:range xsd:string ;
-    skos:definition "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
-    skos:exactMatch <bibo:locator> ;
+dlres:PersonalRequest a owl:Class ;
+    rdfs:label "PersonalRequest" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlthings:description ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlthings:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:description ],
+        dlres:AccessMethod ;
+    skos:definition "The act of personally making a request to get access to the subject by following some described procedure." ;
+    skos:exactMatch dlres:PersonalRequest ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
-dlres:resource a owl:ObjectProperty ;
-    rdfs:label "resource" ;
-    rdfs:range dlres:Resource ;
-    skos:definition "Property referencing a resource within an indexed-part or indexed-part-of qualified relationship." ;
+dlres:previous_version a owl:ObjectProperty ;
+    rdfs:label "previous_version" ;
+    skos:definition "The previous version of the subject in a lineage." ;
+    skos:exactMatch pav:previousVersion,
+        dcat:previousVersion ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
 dlres:sponsor a owl:ObjectProperty ;
     rdfs:label "sponsor" ;
     rdfs:range dlprov:Agent ;
     skos:definition "An agent that supports a thing through a pledge, promise, or financial contribution." ;
-    skos:exactMatch schema1:sponsor ;
+    skos:exactMatch <schema:sponsor> ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+
+dlres:version_label a owl:DatatypeProperty ;
+    rdfs:label "version_label" ;
+    rdfs:range xsd:string ;
+    skos:definition "Version indicator (name or identifier) of the subject." ;
+    skos:exactMatch pav:version,
+        dcat:version ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+
+dlsocial:Group a owl:Class ;
+    rdfs:label "Group" ;
+    rdfs:subClassOf dlprov:Agent ;
+    skos:definition "A collection of individual agents. A group may itself play the role of an agent." ;
+    skos:exactMatch foaf:Group,
+        dlsocial:Group ;
+    skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
 dlsocial:Organization a owl:Class ;
     rdfs:label "Organization" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty dlprops:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dlprops:short_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
             owl:onProperty dlprops:name ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlprops:short_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlprops:name ],
+            owl:onProperty dlprops:short_name ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty dlprops:short_name ],
         dlprov:Agent ;
     skos:definition "A social or legal instititution such as a company, a society, or a university." ;
-    skos:exactMatch <foaf:Organization>,
+    skos:exactMatch foaf:Organization,
         dlsocial:Organization,
         <prov:Organization> ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> ;
@@ -563,14 +641,17 @@ dlsocial:Organization a owl:Class ;
 dlsocial:Person a owl:Class ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlsocial:honorific_name_suffix ],
+            owl:minCardinality 0 ;
+            owl:onProperty dlsocial:family_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlsocial:honorific_name_suffix ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty dlsocial:given_name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dlsocial:honorific_name_suffix ],
+            owl:onProperty dlsocial:given_name ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlsocial:honorific_name_prefix ],
@@ -578,8 +659,8 @@ dlsocial:Person a owl:Class ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlsocial:family_name ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlsocial:family_name ],
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlsocial:additional_names ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlsocial:honorific_name_prefix ],
@@ -588,34 +669,31 @@ dlsocial:Person a owl:Class ;
             owl:onProperty dlsocial:additional_names ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlsocial:formatted_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty dlsocial:honorific_name_suffix ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlsocial:given_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlsocial:formatted_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlsocial:formatted_name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
             owl:onProperty dlsocial:family_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlsocial:formatted_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlsocial:formatted_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlsocial:given_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlsocial:given_name ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlsocial:formatted_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlsocial:honorific_name_prefix ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlsocial:additional_names ],
+            owl:maxCardinality 1 ;
+            owl:onProperty dlsocial:honorific_name_suffix ],
         dlprov:Agent ;
     skos:definition "Person agents are people, alive, dead, or fictional." ;
-    skos:exactMatch <foaf:Person>,
+    skos:exactMatch foaf:Person,
         dlsocial:Person,
         <prov:Person> ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> ;
@@ -624,28 +702,28 @@ dlsocial:Person a owl:Class ;
 dlsocial:Project a owl:Class ;
     rdfs:label "Project" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlprops:short_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty dlprops:short_name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlprops:short_name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:short_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlprops:title ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlprops:title ],
         dlprov:Activity ;
     skos:broadMatch obo:BFO_0000015 ;
     skos:closeMatch obo:NCIT_C47885 ;
     skos:definition "A collective endeavour of some kind. Typically it is a planned process that is undertaken or attempted to meet some requirement, or to achieve a particular goal." ;
-    skos:exactMatch <foaf:Project>,
+    skos:exactMatch foaf:Project,
         dlsocial:Project ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
@@ -654,8 +732,8 @@ dlsocial:family_name a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "The (inherited) family name of the subject. In many Western languages this is the \"last name\"." ;
-    skos:exactMatch <foaf:familyName>,
-        <vcard:family-name> ;
+    skos:exactMatch vcard:family-name,
+        foaf:familyName ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
 dlsocial:formatted_name a owl:DatatypeProperty ;
@@ -663,7 +741,7 @@ dlsocial:formatted_name a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "A formatted text corresponding to the name of the subject." ;
-    skos:exactMatch <vcard:fn> ;
+    skos:exactMatch vcard:fn ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
 dlsocial:given_name a owl:DatatypeProperty ;
@@ -671,8 +749,8 @@ dlsocial:given_name a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "The given (non-inherited) name of the subject." ;
-    skos:exactMatch <foaf:familyName>,
-        <vcard:given-name> ;
+    skos:exactMatch vcard:given-name,
+        foaf:familyName ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
 dlsocial:honorific_name_prefix a owl:DatatypeProperty ;
@@ -680,7 +758,7 @@ dlsocial:honorific_name_prefix a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "The honorific prefix(es) of the subject's name. For example, (academic/formal) titles like \"Mrs\", or \"Dr\", \"Dame\"." ;
-    skos:exactMatch <vcard:honorific-suffix> ;
+    skos:exactMatch vcard:honorific-suffix ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
 
 dlsocial:honorific_name_suffix a owl:DatatypeProperty ;
@@ -688,8 +766,62 @@ dlsocial:honorific_name_suffix a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     rdfs:subPropertyOf dlprops:name ;
     skos:definition "The honorific suffix(es) of the subject's name. For example, generation labels (\"III\"), or indicators of an academic degree, a profession, or a position (\"MD\", \"BA\")." ;
-    skos:exactMatch <vcard:honorific-suffix> ;
+    skos:exactMatch vcard:honorific-suffix ;
     skos:inScheme <https://concepts.datalad.org/s/social/unreleased> .
+
+dltemporal:InstantaneousEvent a owl:Class ;
+    rdfs:label "InstantaneousEvent" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:at_time ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlroles:Relationship ;
+            owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:at_time ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlidentifiers:Identifier ;
+            owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:at_time ],
+        dlthings:Thing ;
+    skos:definition "A moment of a transition from one particular state of the world to another." ;
+    skos:exactMatch dltemporal:InstantaneousEvent,
+        <prov:InstantaneousEvent> ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
+
+dltemporal:TransientRelationship a owl:Class ;
+    rdfs:label "TransientRelationship" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:started_at ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:ended_at ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:ended_at ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:started_at ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:started_at ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:ended_at ],
+        dlroles:Relationship ;
+    skos:definition "A relationship that is valid or remains in place for a limited time." ;
+    skos:exactMatch dltemporal:TransientRelationship ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
 
 dltemporal:at_time a owl:DatatypeProperty ;
     rdfs:label "at_time" ;
@@ -698,52 +830,22 @@ dltemporal:at_time a owl:DatatypeProperty ;
     skos:exactMatch <prov:atTime> ;
     skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
 
-dltemporal:date_modified a owl:DatatypeProperty ;
-    rdfs:label "date_modified" ;
-    rdfs:range w3ctr:NOTE-datetime ;
-    skos:definition "Timepoint at which the subject was (last) changed, updated or modified." ;
-    skos:editorialNote "a related problem also exists for `linkml-validate`, we cannot have a more specific range right now",
-        "successful validation with `datetime` as a range and linkml-jsonschema-validate` depends on a patched linkml, see https://github.com/linkml/linkml/issues/1806" ;
-    skos:exactMatch <dcterms:modified> ;
-    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
-
-dltemporal:date_published a owl:DatatypeProperty ;
-    rdfs:label "date_published" ;
-    rdfs:range w3ctr:NOTE-datetime ;
-    skos:definition "Timepoint at which the subject was (last) published." ;
-    skos:exactMatch schema1:datePublished ;
-    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
-
-dltemporal:ended_at a owl:DatatypeProperty ;
-    rdfs:label "ended_at" ;
-    rdfs:range w3ctr:NOTE-datetime ;
-    skos:definition "End is when an activity is deemed to have been ended by some trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
-    skos:exactMatch <prov:endedAtTime> ;
-    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
-
-dltemporal:started_at a owl:DatatypeProperty ;
-    rdfs:label "started_at" ;
-    rdfs:range w3ctr:NOTE-datetime ;
-    skos:definition "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
-    skos:exactMatch <prov:startedAtTime> ;
-    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
-
 dlthings:Statement a owl:Class ;
     rdfs:label "Statement" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:object ],
-        [ a owl:Restriction ;
             owl:allValuesFrom dlthings:Property ;
             owl:onProperty dlthings:predicate ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:predicate ],
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlthings:object ],
         [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty dlthings:object ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty dlthings:predicate ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
             owl:onProperty dlthings:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
@@ -753,9 +855,9 @@ dlthings:Statement a owl:Class ;
         dlthings:Statement ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
-dlthings:annotation_tag a owl:DatatypeProperty ;
+dlthings:annotation_tag a owl:ObjectProperty ;
     rdfs:label "annotation_tag" ;
-    rdfs:range xsd:anyURI ;
+    rdfs:range dlthings:Thing ;
     skos:definition "A tag identifying an annotation." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
@@ -765,21 +867,13 @@ dlthings:annotation_value a owl:DatatypeProperty ;
     skos:definition "The actual annotation." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
-dlthings:description a owl:DatatypeProperty ;
-    rdfs:label "description" ;
-    rdfs:range xsd:string ;
-    skos:definition "A free-text account of the subject." ;
-    skos:exactMatch <dcterms:description>,
-        rdfs:comment ;
-    skos:inScheme <https://concepts.datalad.org/s/things/v1> .
-
-dlthings:id a owl:DatatypeProperty ;
-    rdfs:label "id" ;
+dlthings:pid a owl:DatatypeProperty ;
+    rdfs:label "pid" ;
     rdfs:range xsd:anyURI ;
     skos:definition "Persistent and globally unique identifier of a `Thing`." ;
-    skos:exactMatch <ADMS:identifier>,
-        <dcterms:identifier>,
-        schema1:identifier ;
+    skos:exactMatch <dcterms:identifier>,
+        ADMS:identifier,
+        <schema:identifier> ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
 dlthings:range a owl:DatatypeProperty ;
@@ -796,6 +890,64 @@ dlthings:value a owl:DatatypeProperty ;
     skos:exactMatch rdf:value ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
+dledist:ElectronicDistribution a owl:Class ;
+    rdfs:label "ElectronicDistribution" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:checksums ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:byte_size ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dledist:media_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dledist:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:nonNegativeInteger ;
+            owl:onProperty dledist:byte_size ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:media_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlidentifiers:Checksum ;
+            owl:onProperty dledist:checksums ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dledist:byte_size ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dledist:format ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dledist:format ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dledist:media_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dledist:ElectronicDistribution ;
+            owl:onProperty inm7base:previous_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:previous_version ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:previous_version ],
+        dlres:Distribution ;
+    skos:definition "A specific representation of data, which may come in the form of a single file, or an archive or directory of many files, may be standalone or part of a larger collection." ;
+    skos:exactMatch dcat:Distribution,
+        dledist:ElectronicDistribution ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dledist:format a owl:ObjectProperty ;
+    rdfs:label "format" ;
+    rdfs:range dlthings:Thing ;
+    skos:definition "The file format of a distribution." ;
+    skos:editorialNote "When type of the distribution is defined by IANA, `media_type` should be used." ;
+    skos:exactMatch <dcterms:format> ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
 dlidentifiers:ComputedIdentifier a owl:Class ;
     rdfs:label "ComputedIdentifier" ;
     rdfs:subClassOf dlidentifiers:Identifier ;
@@ -811,14 +963,14 @@ dlidentifiers:IssuedIdentifier a owl:Class ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlidentifiers:schema_agency ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
             owl:onProperty dlidentifiers:schema_agency ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty dlidentifiers:schema_agency ],
         dlidentifiers:Identifier ;
     skos:definition "An identifier that was issued by a particular agent with a notation that has no (or an undefined) relation to the nature of the identified entity." ;
-    skos:exactMatch <ADMS:Identifier>,
+    skos:exactMatch ADMS:Identifier,
         dlidentifiers:IssuedIdentifier ;
     skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
 
@@ -829,102 +981,183 @@ dlidentifiers:notation a owl:DatatypeProperty ;
     skos:exactMatch skos:notation ;
     skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
 
-dlroles:roles a owl:ObjectProperty ;
-    rdfs:label "roles" ;
-    rdfs:range dlroles:Role ;
-    skos:definition "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
-    skos:exactMatch <dcat:had_role>,
-        <prov:hadRole> ;
-    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
+dlres:IndexedResourceRelationship a owl:Class ;
+    rdfs:label "IndexedResourceRelationship" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty inm7base:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlres:locator ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Resource ;
+            owl:onProperty inm7base:object ],
+        dlroles:Relationship ;
+    skos:definition "An association class for attaching a `locator` as additional information to a `hasPart` relationship." ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+
+dlres:distribution_of a owl:ObjectProperty ;
+    rdfs:label "distribution_of" ;
+    rdfs:domain dlres:Distribution ;
+    rdfs:range dlres:Resource ;
+    owl:inverseOf dlres:distributions ;
+    skos:broadMatch <sio:SIO_000426> ;
+    skos:definition "The resource that the subject is a distribution of." ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
 dlthings:AttributeSpecification a owl:Class ;
     rdfs:label "AttributeSpecification" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty dlthings:predicate ],
+        [ a owl:Restriction ;
             owl:allValuesFrom dlthings:Property ;
             owl:onProperty dlthings:predicate ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty dlthings:predicate ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:predicate ],
         dlthings:ThingMixin,
         dlthings:ValueSpecificationMixin ;
     skos:closeMatch dlthings:Thing ;
-    skos:definition "An attribute is conceptually a thing, but it requires no dedicated identifier (`id`). Instead, it is linked to a `Thing` via its `attributes` slot and declares a `predicate` on the nature of the relationship." ;
-    skos:exactMatch sio:SIO_000614 ;
+    skos:definition "An attribute is conceptually a thing, but it requires no dedicated identifier (`pid`). Instead, it is linked to a `Thing` via its `attributes` slot and declares a `predicate` on the nature of the relationship." ;
+    skos:exactMatch <sio:SIO_000614> ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
 dlthings:ThingMixin a owl:Class ;
     rdfs:label "ThingMixin" ;
     rdfs:subClassOf [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:narrow_mappings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlthings:Annotation ;
-            owl:onProperty dlthings:annotations ],
+            owl:onProperty dlthings:close_mappings ],
         [ a owl:Restriction ;
             owl:allValuesFrom rdfs:Resource ;
             owl:onProperty dltypes:schema_type ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:exact_mappings ],
+            owl:allValuesFrom dlthings:Annotation ;
+            owl:onProperty dlthings:annotations ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlthings:description ],
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dlthings:broad_mappings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlthings:characterized_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:close_mappings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dlthings:narrow_mappings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
             owl:onProperty dlthings:related_mappings ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty dlthings:description ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlthings:close_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:broad_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:attributes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:annotations ],
+            owl:onProperty dlthings:narrow_mappings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlthings:exact_mappings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlthings:broad_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
             owl:onProperty dltypes:schema_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dltypes:schema_type ],
+            owl:onProperty dlthings:description ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:close_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:narrow_mappings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:broad_mappings ],
+            owl:onProperty dlthings:exact_mappings ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlthings:Statement ;
             owl:onProperty dlthings:characterized_by ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlthings:description ],
+            owl:onProperty dlthings:annotations ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlthings:AttributeSpecification ;
             owl:onProperty dlthings:attributes ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
+            owl:minCardinality 0 ;
             owl:onProperty dlthings:related_mappings ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlthings:characterized_by ] ;
+            owl:onProperty dlthings:attributes ] ;
     skos:definition "Mix-in with the common interface of `Thing` and `AttributeSpecification`. This interface enables type specifications (`rdf:type`) for things and attributes via a `type` designator slot to indicate specialized schema classes for validation where a slot's `range` is too generic. A thing or attribute can be further describe with statements on qualified relations to other things (`characterized_by`), or inline attributes (`attributes`). A set of `mappings` slots enables the alignment for arbitrary external schemas and terminologies." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
+
+rdfs:Resource a rdfs:Datatype ;
+    owl:equivalentClass xsd:anyURI .
+
+dledist:DataService a owl:Class ;
+    rdfs:label "DataService" ;
+    rdfs:subClassOf dlres:Resource ;
+    skos:definition "A collection of operations that provides access to one or more dataset distributions or data processing functions." ;
+    skos:exactMatch dcat:DataService,
+        dledist:DataService ;
+    skos:inScheme <https://concepts.datalad.org/s/edistributions/unreleased> .
+
+dlidentifiers:Checksum a owl:Class ;
+    rdfs:label "Checksum" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom xsd:hexBinary ;
+            owl:onProperty inm7base:notation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty inm7base:creator ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:creator ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:notation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty inm7base:notation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:creator ],
+        dlidentifiers:ComputedIdentifier ;
+    skos:definition "A Checksum is a value that allows to check the integrity of the contents of a file. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented." ;
+    skos:exactMatch dlidentifiers:Checksum,
+        <spdx:Checksum> ;
+    skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
+
+dlres:distributions a owl:ObjectProperty ;
+    rdfs:label "distributions" ;
+    rdfs:domain dlres:Resource ;
+    rdfs:range dlres:Distribution ;
+    owl:inverseOf dlres:distribution_of ;
+    skos:broadMatch <sio:SIO_000341> ;
+    skos:definition "Available distributions of the resource." ;
+    skos:exactMatch dcat:distribution ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
+
+dlroles:Role a owl:Class ;
+    rdfs:label "Role" ;
+    rdfs:subClassOf dlthings:Thing ;
+    skos:definition "A role is the function of a resource or agent with respect to a subject, in the context of resource attribution or relationships." ;
+    skos:exactMatch dcat:Role,
+        dlroles:Role,
+        <prov:Role> ;
+    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
 
 dlthings:mappings a owl:DatatypeProperty ;
     rdfs:label "mappings" ;
@@ -932,14 +1165,12 @@ dlthings:mappings a owl:DatatypeProperty ;
     skos:definition "A list of terms from different schemas or terminology systems that have comparable meaning. These may include terms that are precisely equivalent, broader or narrower in meaning, or otherwise semantically related but not equivalent from a strict ontological perspective." ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
-dlroles:Role a owl:Class ;
-    rdfs:label "Role" ;
-    rdfs:subClassOf dlthings:Thing ;
-    skos:definition "A role is the function of a resource or agent with respect to a subject, in the context of resource attribution or relationships." ;
-    skos:exactMatch <dcat:Role>,
-        dlroles:Role,
-        <prov:Role> ;
-    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
+dlres:locator a owl:DatatypeProperty ;
+    rdfs:label "locator" ;
+    rdfs:range xsd:string ;
+    skos:definition "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+    skos:exactMatch bibo:locator ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> .
 
 dlspatial:Location a owl:Class ;
     rdfs:label "Location" ;
@@ -947,14 +1178,14 @@ dlspatial:Location a owl:Class ;
             owl:allValuesFrom dlroles:Relationship ;
             owl:onProperty dlroles:qualified_relations ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlidentifiers:identifiers ],
-        [ a owl:Restriction ;
             owl:allValuesFrom dlidentifiers:Identifier ;
             owl:onProperty dlidentifiers:identifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlidentifiers:identifiers ],
         dlthings:Thing ;
     skos:definition "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth." ;
     skos:exactMatch dlspatial:Location,
@@ -968,6 +1199,37 @@ dlspatial:at_location a owl:ObjectProperty ;
     skos:exactMatch <prov:atLocation> ;
     skos:inScheme <https://concepts.datalad.org/s/spatial/unreleased> .
 
+dltemporal:date_modified a owl:DatatypeProperty ;
+    rdfs:label "date_modified" ;
+    rdfs:range w3ctr:NOTE-datetime ;
+    skos:definition "Timepoint at which the subject was (last) changed, updated or modified." ;
+    skos:editorialNote "a related problem also exists for `linkml-validate`, we cannot have a more specific range right now",
+        "successful validation with `datetime` as a range and linkml-jsonschema-validate` depends on a patched linkml, see https://github.com/linkml/linkml/issues/1806" ;
+    skos:exactMatch <dcterms:modified> ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
+
+dltemporal:date_published a owl:DatatypeProperty ;
+    rdfs:label "date_published" ;
+    rdfs:range w3ctr:NOTE-datetime ;
+    skos:definition "Timepoint at which the subject was (last) published." ;
+    skos:exactMatch <dcterms:issued>,
+        <schema:datePublished> ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
+
+dltemporal:ended_at a owl:DatatypeProperty ;
+    rdfs:label "ended_at" ;
+    rdfs:range w3ctr:NOTE-datetime ;
+    skos:definition "End is when an activity is deemed to have been ended by some trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
+    skos:exactMatch <prov:endedAtTime> ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
+
+dltemporal:started_at a owl:DatatypeProperty ;
+    rdfs:label "started_at" ;
+    rdfs:range w3ctr:NOTE-datetime ;
+    skos:definition "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
+    skos:exactMatch <prov:startedAtTime> ;
+    skos:inScheme <https://concepts.datalad.org/s/temporal/unreleased> .
+
 dlthings:Property a owl:Class ;
     rdfs:label "Property" ;
     rdfs:subClassOf dlthings:Thing ;
@@ -976,10 +1238,19 @@ dlthings:Property a owl:Class ;
         dlthings:Property ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
-dlthings:object a owl:DatatypeProperty ;
+dlthings:description a owl:DatatypeProperty ;
+    rdfs:label "description" ;
+    rdfs:range xsd:string ;
+    skos:broadMatch IAO:0000300 ;
+    skos:definition "A free-text account of the subject." ;
+    skos:exactMatch <dcterms:description>,
+        rdfs:comment ;
+    skos:inScheme <https://concepts.datalad.org/s/things/v1> .
+
+dlthings:object a owl:ObjectProperty ;
     rdfs:label "object" ;
-    rdfs:range xsd:anyURI ;
     skos:definition "Reference to a `Thing` within a `Statement`." ;
+    skos:editorialNote "We do not declare a range here to be able to tighten the range in subclasses of class that need a particular range. This appears to be working around a linkml limitation." ;
     skos:exactMatch rdf:object ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
@@ -995,32 +1266,9 @@ dlprops:title a owl:DatatypeProperty ;
     rdfs:range xsd:string ;
     skos:definition "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
     skos:exactMatch <dcterms:title>,
-        sio:SIO_000185 ;
+        <sio:SIO_000185> ;
     skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> ;
-    skos:relatedMatch schema1:name .
-
-dlroles:Relationship a owl:Class ;
-    rdfs:label "Relationship" ;
-    rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom dlroles:Role ;
-            owl:onProperty dlroles:roles ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:object ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlthings:object ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:object ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlroles:roles ] ;
-    skos:closeMatch <dcat:Relationship>,
-        <prov:Influence> ;
-    skos:definition "An association class for characterizing the relation between two things with the role(s) the object had with respect to the subject. A relationship is always between two things only, but can be annotated with multiple roles (for example, a person having both an author role with respect to a dataset, and also being the person who is legally responsible contact for it)." ;
-    skos:exactMatch dlroles:Relationship ;
-    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
+    skos:relatedMatch <schema:name> .
 
 dlprops:short_name a owl:DatatypeProperty ;
     rdfs:label "short_name" ;
@@ -1033,144 +1281,111 @@ dlprops:short_name a owl:DatatypeProperty ;
 dlprov:Entity a owl:Class ;
     rdfs:label "Entity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom dlprov:Entity ;
+            owl:minCardinality 0 ;
             owl:onProperty dlprov:derived_from ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlidentifiers:identifiers ],
+            owl:allValuesFrom dlprov:Entity ;
+            owl:onProperty dlprov:derived_from ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlroles:Relationship ;
             owl:onProperty dlroles:qualified_relations ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
+            owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprov:generated_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlprov:Agent ;
             owl:onProperty dlprov:attributed_to ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprov:attributed_to ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlidentifiers:Identifier ;
             owl:onProperty dlidentifiers:identifiers ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlprov:Activity ;
             owl:onProperty dlprov:generated_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprov:generated_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprov:derived_from ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlprov:Agent ;
-            owl:onProperty dlprov:attributed_to ],
         dlthings:Thing ;
     skos:definition "A physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary." ;
     skos:exactMatch dlprov:Entity,
         <prov:Entity> ;
     skos:inScheme <https://concepts.datalad.org/s/prov/unreleased> .
 
-dlres:Resource a owl:Class ;
-    rdfs:label "Resource" ;
+dlres:AccessMethod a owl:Class ;
+    rdfs:label "AccessMethod" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlprops:about ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlprops:short_name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprops:short_name ],
+            owl:allValuesFrom rdfs:Resource ;
+            owl:onProperty dltypes:schema_type ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dlprops:short_name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlres:IndexedResourcePart ;
-            owl:onProperty dlres:indexed_parts ],
+            owl:onProperty dltypes:schema_type ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlprops:about ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlres:indexed_part_of ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlprops:same_as ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty dlprops:title ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprops:same_as ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlres:indexed_parts ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlres:IndexedResourcePartOf ;
-            owl:onProperty dlres:indexed_part_of ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlprops:same_as ],
-        dlprov:Entity ;
-    skos:definition "A consumable, often quantifiable entity, typically made available by a single agent." ;
-    skos:exactMatch dlres:Resource ;
+            owl:onProperty dltypes:schema_type ] ;
+    skos:definition "An approach or procedure to gain access to the subject." ;
+    skos:exactMatch dlres:AccessMethod ;
     skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> ;
-    skos:narrowMatch <dcat:Resource> .
+    skos:note "This is merely a base class for range declaration. It does not define any slots other than a type designator, because little or no commonalities of properties across access methods are to be expected." .
+
+dlres:Distribution a owl:Class ;
+    rdfs:label "Distribution" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:previous_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlres:distribution_of ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Resource ;
+            owl:onProperty dlres:distribution_of ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:distribution_of ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:previous_version ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Distribution ;
+            owl:onProperty inm7base:previous_version ],
+        dlres:Resource ;
+    skos:definition "A specific representation of a resource, which may come in the form of a physical object, or an electronic file, or an archive or directory of many files, may be standalone or part of a larger collection." ;
+    skos:editorialNote "A `Distribution` is derived from `Resource`, following the logic that it is a materialized/specialized variant of a particular resource. It therefore should inherit all its slots. This is in contrast to DCAT, where `Distribution` is not a subclass. However, in DCAT a `Distribution` also does not have a version. Here we do want that, for example, to express an update of a format conversion, where no data change, only the layout." ;
+    skos:exactMatch dlres:Distribution ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> ;
+    skos:narrowMatch dcat:Distribution .
 
 dlidentifiers:identifiers a owl:ObjectProperty ;
     rdfs:label "identifiers" ;
     rdfs:range dlidentifiers:Identifier ;
     skos:definition "An unambiguous reference to the subject within a given context." ;
-    skos:exactMatch <ADMS:identifier>,
-        <dcterms:identifier>,
-        schema1:identifier ;
+    skos:exactMatch <dcterms:identifier>,
+        ADMS:identifier,
+        <schema:identifier> ;
     skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
 
 dlprops:name a owl:DatatypeProperty ;
     rdfs:label "name" ;
     rdfs:range xsd:string ;
-    skos:closeMatch dlprops:title ;
+    skos:closeMatch IAO:0000590,
+        dlprops:title ;
     skos:definition "Name of the subject. A name is closely related to a `title`, but often more compact and identifier-like, but without the implication of uniqueness of an identifier. A name is often used by technical systems to display an item in an organizational structure, such as a file in a directory hierarchy." ;
-    skos:exactMatch <foaf:name>,
-        schema1:name,
-        rdfs:label ;
+    skos:exactMatch rdfs:label,
+        foaf:name,
+        <schema:name> ;
     skos:inScheme <https://concepts.datalad.org/s/properties/unreleased> .
 
 dlprov:Activity a owl:Class ;
     rdfs:label "Activity" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom dlidentifiers:Identifier ;
-            owl:onProperty dlidentifiers:identifiers ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlspatial:at_location ],
+            owl:onProperty dlprov:informed_by ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dltemporal:ended_at ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlprov:Activity ;
-            owl:onProperty dlprov:informed_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dltemporal:started_at ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlprov:informed_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlroles:Relationship ;
-            owl:onProperty dlroles:qualified_relations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom w3ctr:NOTE-datetime ;
-            owl:onProperty dltemporal:ended_at ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlroles:qualified_relations ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty dltemporal:ended_at ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlprov:Agent ;
@@ -1179,23 +1394,48 @@ dlprov:Activity a owl:Class ;
             owl:allValuesFrom dlspatial:Location ;
             owl:onProperty dlspatial:at_location ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlspatial:at_location ],
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:ended_at ],
         [ a owl:Restriction ;
             owl:allValuesFrom w3ctr:NOTE-datetime ;
-            owl:onProperty dltemporal:started_at ],
+            owl:onProperty dltemporal:ended_at ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlprov:associated_with ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
+            owl:minCardinality 0 ;
             owl:onProperty dltemporal:started_at ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:started_at ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlprov:Activity ;
+            owl:onProperty dlprov:informed_by ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlspatial:at_location ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlidentifiers:Identifier ;
+            owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlroles:Relationship ;
+            owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlroles:qualified_relations ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlspatial:at_location ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:started_at ],
         dlthings:Thing ;
     skos:definition "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
-    skos:exactMatch dlprov:Activity,
+    skos:exactMatch obo:BFO_0000015,
+        dlprov:Activity,
         <prov:Activity> ;
     skos:inScheme <https://concepts.datalad.org/s/prov/unreleased> ;
     skos:note "This class does not support even a basic `name` slot, because depending on the context, there may not be a suitable name, or one name would not be enough. If no specialized derived class is available in a context where a `name` or similar attribute is desired, it can be expressed via the `has_attributes` slot." .
@@ -1205,7 +1445,73 @@ dlroles:qualified_relations a owl:ObjectProperty ;
     rdfs:domain dlthings:Thing ;
     rdfs:range dlroles:Relationship ;
     skos:definition "Characterizes the relationship or role of an entity with respect to the subject." ;
-    skos:exactMatch <dcat:qualifiedRelation> ;
+    skos:exactMatch dcat:qualifiedRelation ;
+    skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
+
+dlidentifiers:Identifier a owl:Class ;
+    rdfs:label "Identifier" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlidentifiers:creator ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlidentifiers:notation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlidentifiers:notation ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty dlidentifiers:notation ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom rdfs:Resource ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dlidentifiers:creator ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlidentifiers:creator ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltypes:schema_type ] ;
+    skos:closeMatch ADMS:Identifier ;
+    skos:definition "An identifier is a label that uniquely identifies an item in a particular context. Some identifiers are globally unique. All identifiers are unique within their individual scope." ;
+    skos:exactMatch dlidentifiers:Identifier ;
+    skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
+
+dlroles:Relationship a owl:Class ;
+    rdfs:label "Relationship" ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlthings:object ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom rdfs:Resource ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlthings:object ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltypes:schema_type ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlroles:roles ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlroles:Role ;
+            owl:onProperty dlroles:roles ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty dlthings:object ] ;
+    skos:closeMatch dcat:Relationship,
+        <prov:Influence> ;
+    skos:definition "An association class for characterizing the relation between two things with the role(s) the object had with respect to the subject. A relationship is always between two things only, but can be annotated with multiple roles (for example, a person having both an author role with respect to a dataset, and also being the person who is legally responsible contact for it)." ;
+    skos:exactMatch dlroles:Relationship ;
     skos:inScheme <https://concepts.datalad.org/s/roles/unreleased> .
 
 w3ctr:NOTE-datetime a rdfs:Datatype ;
@@ -1214,48 +1520,127 @@ w3ctr:NOTE-datetime a rdfs:Datatype ;
                         owl:onDatatype xsd:string ;
                         owl:withRestrictions ( [ xsd:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ] ) ] ) ] .
 
-dlidentifiers:Identifier a owl:Class ;
-    rdfs:label "Identifier" ;
+dlres:Resource a owl:Class ;
+    rdfs:label "Resource" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlidentifiers:notation ],
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:keywords ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty dltypes:schema_type ],
+            owl:onProperty dlprops:title ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlidentifiers:creator ],
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:about ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:version_notes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlprops:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlprops:same_as ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:title ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:previous_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlprops:conforms_to ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlprops:short_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:date_modified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:date_published ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:version_label ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:Resource ;
+            owl:onProperty dlres:previous_version ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
-            owl:onProperty dlidentifiers:notation ],
+            owl:onProperty dlprops:title ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlidentifiers:creator ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlidentifiers:notation ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom rdfs:Resource ;
-            owl:onProperty dltypes:schema_type ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlidentifiers:creator ],
+            owl:onProperty dlprops:short_name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dltypes:schema_type ] ;
-    skos:closeMatch <ADMS:Identifier> ;
-    skos:definition "An identifier is a label that uniquely identifies an item in a particular context. Some identifiers are globally unique. All identifiers are unique within their individual scope." ;
-    skos:exactMatch dlidentifiers:Identifier ;
-    skos:inScheme <https://concepts.datalad.org/s/identifiers/unreleased> .
+            owl:onProperty dlprops:conforms_to ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom w3ctr:NOTE-datetime ;
+            owl:onProperty dltemporal:date_published ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dltemporal:date_modified ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlres:previous_version ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlres:version_label ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlres:AccessMethod ;
+            owl:onProperty dlres:access_methods ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:date_published ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlthings:Thing ;
+            owl:onProperty dlprops:about ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlprops:same_as ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dltemporal:date_modified ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlres:access_methods ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprops:same_as ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlprops:short_name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlres:version_notes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlres:version_label ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty dlprops:keywords ],
+        dlprov:Entity ;
+    skos:definition "A consumable, often quantifiable entity, typically made available by a single agent." ;
+    skos:exactMatch dlres:Resource ;
+    skos:inScheme <https://concepts.datalad.org/s/resources/unreleased> ;
+    skos:narrowMatch dcat:Resource .
 
 dlprov:Agent a owl:Class ;
     rdfs:label "Agent" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty dlspatial:at_location ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom dlprov:Agent ;
             owl:onProperty dlprov:acted_on_behalf_of ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlidentifiers:Identifier ;
             owl:onProperty dlidentifiers:identifiers ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlspatial:at_location ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlprov:acted_on_behalf_of ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlroles:Relationship ;
             owl:onProperty dlroles:qualified_relations ],
@@ -1264,22 +1649,13 @@ dlprov:Agent a owl:Class ;
             owl:onProperty dlspatial:at_location ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
-            owl:onProperty dlspatial:at_location ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
             owl:onProperty dlidentifiers:identifiers ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty dlroles:qualified_relations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom dlprov:Agent ;
-            owl:onProperty dlprov:acted_on_behalf_of ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlspatial:at_location ],
         dlthings:Thing ;
     skos:definition "Something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity." ;
-    skos:exactMatch <foaf:Agent>,
+    skos:exactMatch foaf:Agent,
         dlprov:Agent,
         <prov:Agent> ;
     skos:inScheme <https://concepts.datalad.org/s/prov/unreleased> ;
@@ -1288,81 +1664,81 @@ dlprov:Agent a owl:Class ;
 dlthings:Thing a owl:Class ;
     rdfs:label "Thing" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:exact_mappings ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty dlthings:id ],
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:broad_mappings ],
         [ a owl:Restriction ;
             owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:annotations ],
+            owl:onProperty inm7base:exact_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty dlthings:relations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:attributes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:broad_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:characterized_by ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty dlthings:pid ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:anyURI ;
+            owl:onProperty dlthings:pid ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:attributes ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:related_mappings ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty inm7base:description ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:narrow_mappings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:narrow_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:close_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:exact_mappings ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:annotations ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:characterized_by ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom owl:Thing ;
+            owl:onProperty inm7base:close_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:related_mappings ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty inm7base:annotations ],
         [ a owl:Restriction ;
             owl:allValuesFrom dlthings:Thing ;
             owl:onProperty dlthings:relations ],
         [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:attributes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:broad_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:narrow_mappings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:narrow_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty dlthings:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:annotations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:close_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:attributes ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:related_mappings ],
-        [ a owl:Restriction ;
             owl:maxCardinality 1 ;
-            owl:onProperty trr379base:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:anyURI ;
-            owl:onProperty dlthings:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:description ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:related_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:close_mappings ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:characterized_by ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty dlthings:relations ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:exact_mappings ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty trr379base:characterized_by ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom owl:Thing ;
-            owl:onProperty trr379base:broad_mappings ],
+            owl:onProperty dlthings:pid ],
         dlthings:ThingMixin ;
-    skos:definition "The most basic, identifiable item. In addition to the slots that are common between a `Thing` and an `AttributeSpecification` (see `ThingMixin`), two additional slots are provided. The `id` slot takes the required identifier for a `Thing`. The `relation` slot allows for the inline specification of other `Thing` instances. Such a relation is unqualified (and symmetric), and should be further characterized via a `Statement` (see `characterized_by`). From a schema perspective, the `relation` slots allows for building self-contained, structured documents (e.g., a JSON object) with arbitrarily complex information on a `Thing`." ;
-    skos:exactMatch schema1:Thing,
-        dlthings:Thing ;
+    skos:definition "The most basic, identifiable item. In addition to the slots that are common between a `Thing` and an `AttributeSpecification` (see `ThingMixin`), two additional slots are provided. The `pid` slot takes the required identifier for a `Thing`. The `relation` slot allows for the inline specification of other `Thing` instances. Such a relation is unqualified (and symmetric), and should be further characterized via a `Statement` (see `characterized_by`). From a schema perspective, the `relation` slots allows for building self-contained, structured documents (e.g., a JSON object) with arbitrarily complex information on a `Thing`." ;
+    skos:exactMatch dlthings:Thing,
+        <schema:Thing> ;
     skos:inScheme <https://concepts.datalad.org/s/things/v1> .
 
 dltypes:schema_type a owl:DatatypeProperty ;
@@ -1373,34 +1749,9 @@ dltypes:schema_type a owl:DatatypeProperty ;
     skos:inScheme <https://concepts.datalad.org/s/types/unreleased> .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf dlpubs:Publication ;
+    rdfs:subClassOf dlsocial:Project ;
     owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlpubs:Publication .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlres:Instrument ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlres:Instrument .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlroles:Role ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlroles:Role .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlidentifiers:Checksum ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlidentifiers:Checksum .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlprov:Activity ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlprov:Activity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlres:Resource ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlres:Resource .
+    owl:someValuesFrom dlsocial:Project .
 
 [] a owl:Restriction ;
     rdfs:subClassOf dlthings:Property ;
@@ -1408,84 +1759,9 @@ dltypes:schema_type a owl:DatatypeProperty ;
     owl:someValuesFrom dlthings:Property .
 
 [] a owl:Restriction ;
-    rdfs:subClassOf dlspatial:Location ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlspatial:Location .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlres:Dataset ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlres:Dataset .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlthings:AttributeSpecification ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlthings:AttributeSpecification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlidentifiers:Identifier ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlidentifiers:Identifier .
-
-[] a owl:Restriction ;
     rdfs:subClassOf dlthings:Thing ;
     owl:onProperty dltypes:schema_type ;
     owl:someValuesFrom dlthings:Thing .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dltemporal:InstantaneousEvent ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dltemporal:InstantaneousEvent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlprov:Agent ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlprov:Agent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlprov:SoftwareAgent ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlprov:SoftwareAgent .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlidentifiers:DOI ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlidentifiers:DOI .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlsocial:Project ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlsocial:Project .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlres:Grant ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlres:Grant .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlsocial:Person ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlsocial:Person .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlthings:ValueSpecification ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlthings:ValueSpecification .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlprov:Entity ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlprov:Entity .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlsocial:Organization ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlsocial:Organization .
-
-[] a owl:Restriction ;
-    rdfs:subClassOf dlthings:ThingMixin ;
-    owl:onProperty dltypes:schema_type ;
-    owl:someValuesFrom dlthings:ThingMixin .
 
 [] a owl:Restriction ;
     rdfs:subClassOf dlidentifiers:IssuedIdentifier ;
@@ -1493,8 +1769,183 @@ dltypes:schema_type a owl:DatatypeProperty ;
     owl:someValuesFrom dlidentifiers:IssuedIdentifier .
 
 [] a owl:Restriction ;
+    rdfs:subClassOf dlprov:Entity ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlprov:Entity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:IndexedResourcePartOf ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:IndexedResourcePartOf .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dledist:DataService ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dledist:DataService .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlprov:Activity ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlprov:Activity .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dledist:AccessThroughLandingPage ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dledist:AccessThroughLandingPage .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:AccessMethod ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:AccessMethod .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Document ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Document .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlsocial:Person ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlsocial:Person .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dledist:ElectronicDistribution ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dledist:ElectronicDistribution .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlsocial:Group ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlsocial:Group .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlprov:Agent ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlprov:Agent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlidentifiers:DOI ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlidentifiers:DOI .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlspatial:Location ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlspatial:Location .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:IndexedResourcePart ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:IndexedResourcePart .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlpubs:Publication ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlpubs:Publication .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlthings:ThingMixin ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlthings:ThingMixin .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dltemporal:InstantaneousEvent ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dltemporal:InstantaneousEvent .
+
+[] a owl:Restriction ;
     rdfs:subClassOf dlidentifiers:ComputedIdentifier ;
     owl:onProperty dltypes:schema_type ;
     owl:someValuesFrom dlidentifiers:ComputedIdentifier .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:IndexedResourceRelationship ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:IndexedResourceRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlroles:Role ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlroles:Role .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Resource ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Resource .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlroles:Relationship ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlroles:Relationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Dataset ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Dataset .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Grant ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Grant .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Instrument ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Instrument .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlthings:AttributeSpecification ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlthings:AttributeSpecification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dledist:DataServiceAccess ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dledist:DataServiceAccess .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:Distribution ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:Distribution .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlprov:SoftwareAgent ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlprov:SoftwareAgent .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlidentifiers:Checksum ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlidentifiers:Checksum .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlres:PersonalRequest ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlres:PersonalRequest .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dltemporal:TransientRelationship ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dltemporal:TransientRelationship .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlsocial:Organization ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlsocial:Organization .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlthings:ValueSpecification ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlthings:ValueSpecification .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dledist:DirectDownload ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dledist:DirectDownload .
+
+[] a owl:Restriction ;
+    rdfs:subClassOf dlidentifiers:Identifier ;
+    owl:onProperty dltypes:schema_type ;
+    owl:someValuesFrom dlidentifiers:Identifier .
 
 

--- a/public/dlschemas_shacl.ttl
+++ b/public/dlschemas_shacl.ttl
@@ -1,3 +1,4 @@
+@prefix dledist: <https://concepts.datalad.org/s/edistributions/unreleased/> .
 @prefix dlidentifiers: <https://concepts.datalad.org/s/identifiers/unreleased/> .
 @prefix dlprops: <https://concepts.datalad.org/s/properties/unreleased/> .
 @prefix dlprov: <https://concepts.datalad.org/s/prov/unreleased/> .
@@ -15,38 +16,78 @@
 @prefix w3ctr: <https://www.w3.org/TR/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dlidentifiers:Checksum a sh:NodeShape ;
+dledist:AccessThroughLandingPage a sh:NodeShape ;
     sh:closed true ;
-    sh:description "A Checksum is a value that allows to check the integrity of the contents of a file. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented." ;
+    sh:description "Access to the subject through a web page, or information on a web page, that can be navigated to in a Web browser." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:hexBinary ;
-            sh:description "Lower case hexadecimal encoded checksum digest value." ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A Web page that can be navigated to in a Web browser to gain access to a resource." ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlidentifiers:notation ;
-            sh:pattern "^[a-fA-F0-9]+$" ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Identifies the software agent (algorithm) used to produce the subject `Checksum`." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path dlidentifiers:creator ],
+            sh:path dledist:landing_page ],
         [ sh:datatype rdfs:Resource ;
             sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 2 ;
+            sh:order 1 ;
             sh:path rdf:type ] ;
-    sh:targetClass dlidentifiers:Checksum .
+    sh:targetClass dledist:AccessThroughLandingPage .
+
+dledist:DataServiceAccess a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Access through a data service where the subject is available via a particular locator." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlres:locator ],
+        [ sh:class dledist:DataService ;
+            sh:description "A data service that gives access to the distribution of a dataset." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dledist:data_service ] ;
+    sh:targetClass dledist:DataServiceAccess .
+
+dledist:DirectDownload a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Direct access to the subject is possible via a download URL." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "URL that gives direct access to the subject in the form of a downloadable file in a given format." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dledist:download_url ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdf:type ] ;
+    sh:targetClass dledist:DirectDownload .
 
 dlidentifiers:ComputedIdentifier a sh:NodeShape ;
     sh:closed true ;
     sh:description "An identifier that has been derived from information on the identified entity." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:string ;
+    sh:property [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
             sh:description "String of characters such as \"T58:5\" or \"30:4833\" used to uniquely identify a concept within the scope of a given concept scheme." ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -58,13 +99,7 @@ dlidentifiers:ComputedIdentifier a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path dlidentifiers:creator ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path rdf:type ] ;
+            sh:path dlidentifiers:creator ] ;
     sh:targetClass dlidentifiers:ComputedIdentifier .
 
 dlidentifiers:DOI a sh:NodeShape ;
@@ -72,20 +107,6 @@ dlidentifiers:DOI a sh:NodeShape ;
     sh:description "Digital Object Identifier (DOI; ISO 26324), an identifier system governed by the DOI Foundation, where individual identifiers are issued by one of several registration agencies." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:string ;
-            sh:defaultValue "DOI Foundation"^^xsd:string ;
-            sh:description "By default, the schema agency is identified as `DOI Foundation`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlidentifiers:schema_agency ],
-        [ sh:datatype xsd:anyURI ;
-            sh:defaultValue "https://doi.org"^^xsd:anyURI ;
-            sh:description "By default, the creator is identified as \"https://doi.org\"." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlidentifiers:creator ],
-        [ sh:datatype xsd:string ;
             sh:description "The identifier notation is specified without a URL-prefix, or a `doi:` prefix." ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -97,38 +118,52 @@ dlidentifiers:DOI a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 3 ;
-            sh:path rdf:type ] ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:defaultValue "https://doi.org"^^xsd:anyURI ;
+            sh:description "By default, the creator is identified as \"https://doi.org\"." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlidentifiers:creator ],
+        [ sh:datatype xsd:string ;
+            sh:defaultValue "DOI Foundation"^^xsd:string ;
+            sh:description "By default, the schema agency is identified as `DOI Foundation`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlidentifiers:schema_agency ] ;
     sh:targetClass dlidentifiers:DOI .
 
 dlidentifiers:IssuedIdentifier a sh:NodeShape ;
     sh:closed true ;
     sh:description "An identifier that was issued by a particular agent with a notation that has no (or an undefined) relation to the nature of the identified entity." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:description "String of characters such as \"T58:5\" or \"30:4833\" used to uniquely identify a concept within the scope of a given concept scheme." ;
+    sh:property [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
-            sh:minCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path dlidentifiers:notation ],
+            sh:order 3 ;
+            sh:path rdf:type ],
         [ sh:datatype xsd:anyURI ;
             sh:description "An agent responsible for making an entity." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
             sh:path dlidentifiers:creator ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path rdf:type ],
         [ sh:datatype xsd:string ;
             sh:description "Name of the agency that issued an identifier." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path dlidentifiers:schema_agency ] ;
+            sh:path dlidentifiers:schema_agency ],
+        [ sh:datatype xsd:string ;
+            sh:description "String of characters such as \"T58:5\" or \"30:4833\" used to uniquely identify a concept within the scope of a given concept scheme." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlidentifiers:notation ] ;
     sh:targetClass dlidentifiers:IssuedIdentifier .
 
 dlprov:SoftwareAgent a sh:NodeShape ;
@@ -136,12 +171,20 @@ dlprov:SoftwareAgent a sh:NodeShape ;
     sh:description "Running software." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlspatial:at_location ],
         [ sh:class dlthings:Statement ;
             sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -149,6 +192,623 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:acted_on_behalf_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ] ;
+    sh:targetClass dlprov:SoftwareAgent .
+
+dlpubs:Publication a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A document that is the output of a publishing process. This can printed or electronic work offered for distribution, and may have been made available by a publisher." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprops:about ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprops:same_as ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlres:version_label ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_notes ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:title ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlprops:keyword ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlres:previous_version ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path rdf:type ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 14 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ] ;
+    sh:targetClass dlpubs:Publication .
+
+dlres:Dataset a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A collection of data, published or curated by a single agent. This is a conceptual entity. A single dataset might be available in more than one representation, with differing schematic layouts, formats, and serializations." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:generated_by ],
+        [ sh:class dlres:Distribution ;
+            sh:description "Available distributions of the resource." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlres:distributions ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_label ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:short_name ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprops:about ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlprops:title ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:derived_from ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprops:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlres:previous_version ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlprops:keyword ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ] ;
+    sh:targetClass dlres:Dataset .
+
+dlres:Document a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A conceptual entity representing things which a, broadly conceived, \"documents. This includes non-textual things like images. A conceputal document is to be distinguished from its physical, or electronic distributions." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_label ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlprops:keyword ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlres:previous_version ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprops:about ],
+        [ sh:class dlres:Distribution ;
+            sh:description "Available distributions of the resource." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlres:distributions ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path rdf:type ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlprops:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlres:version_notes ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprops:same_as ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -163,13 +823,54 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 3 ;
             sh:path dlthings:attributes ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
+            sh:order 2 ;
+            sh:path dlres:access_method ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ] ;
+    sh:targetClass dlres:Document .
+
+dlres:Grant a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A grant, typically financial or otherwise quantifiable, resources." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlprops:keyword ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:derived_from ],
         [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -178,12 +879,338 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlprov:Agent ;
+            sh:description "An agent that supports a thing through a pledge, promise, or financial contribution." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlres:sponsor ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlres:previous_version ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlres:access_method ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlprops:title ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprops:same_as ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path rdf:type ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_label ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprops:about ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
         [ sh:class dlidentifiers:Identifier ;
             sh:description "An unambiguous reference to the subject within a given context." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlidentifiers:identifier ] ;
+    sh:targetClass dlres:Grant .
+
+dlres:IndexedResourcePart a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An association class for attaching an index `locator` as additional information to a `hasPart` relationship." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlroles:Role ;
+            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
+            sh:nodeKind sh:IRI ;
             sh:order 2 ;
-            sh:path dlidentifiers:identifier ],
+            sh:path dlroles:roles ],
+        [ sh:datatype xsd:string ;
+            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlres:locator ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path rdf:type ],
+        [ sh:class dlres:Resource ;
+            sh:description "Reference to a `Thing` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path rdf:object ] ;
+    sh:targetClass dlres:IndexedResourcePart .
+
+dlres:IndexedResourcePartOf a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An association class for attaching an index `locator` as additional information to a `isPartOf` relationship." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlroles:Role ;
+            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlroles:roles ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path rdf:type ],
+        [ sh:class dlres:Resource ;
+            sh:description "Reference to a `Thing` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path rdf:object ],
+        [ sh:datatype xsd:string ;
+            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlres:locator ] ;
+    sh:targetClass dlres:IndexedResourcePartOf .
+
+dlres:IndexedResourceRelationship a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An association class for attaching a `locator` as additional information to a `hasPart` relationship." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlres:locator ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path rdf:type ],
+        [ sh:class dlroles:Role ;
+            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlroles:roles ],
+        [ sh:class dlres:Resource ;
+            sh:description "Reference to a `Thing` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path rdf:object ] ;
+    sh:targetClass dlres:IndexedResourceRelationship .
+
+dlres:Instrument a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A thing that enables an agent to perform an action. This is typically a device (e.g., a machine to perform a particular type of measurement), but it can also be a questionnaire that is used to perform a particular kind of assessment. An instrument is typically not a \"reagent\"." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprops:about ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprops:same_as ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -192,10 +1219,54 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:order 7 ;
             sh:path skos:exactMatch ],
         [ sh:class dlprov:Agent ;
-            sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
             sh:nodeKind sh:IRI ;
-            sh:order 0 ;
-            sh:path dlprov:acted_on_behalf_of ],
+            sh:order 14 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlprops:keyword ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlres:previous_version ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlprops:short_name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -203,37 +1274,42 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
-            sh:maxCount 1 ;
+            sh:order 12 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
             sh:nodeKind sh:IRI ;
-            sh:order 1 ;
-            sh:path dlspatial:at_location ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:order 15 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path rdf:type ],
+            sh:order 9 ;
+            sh:path dlprops:title ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlres:version_label ],
         [ sh:datatype xsd:string ;
             sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -242,506 +1318,99 @@ dlprov:SoftwareAgent a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 4 ;
             sh:path dlthings:description ] ;
-    sh:targetClass dlprov:SoftwareAgent .
+    sh:targetClass dlres:Instrument .
 
-dlpubs:Publication a sh:NodeShape ;
+dlres:PersonalRequest a sh:NodeShape ;
     sh:closed true ;
-    sh:description "A document that is the output of a publishing process. This can printed or electronic work offered for distribution, and may have been made available by a publisher." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlres:IndexedResourcePartOf ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 4 ;
-            sh:path dlres:indexed_part_of ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path dlprops:short_name ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path dlprops:about ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 9 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlres:IndexedResourcePart ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlres:indexed_parts ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 10 ;
-            sh:path dlprov:attributed_to ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path dlprops:title ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:datatype w3ctr:NOTE-datetime ;
-            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dltemporal:date_modified ;
-            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:datatype w3ctr:NOTE-datetime ;
-            sh:description "Timepoint at which the subject was (last) published." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dltemporal:date_published ;
-            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 12 ;
-            sh:path dlprov:generated_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 8 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 13 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlprops:same_as ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:class dlprov:Entity ;
-            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 11 ;
-            sh:path dlprov:derived_from ] ;
-    sh:targetClass dlpubs:Publication .
-
-dlres:Dataset a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A collection of data, published or curated by a single agent. This is a conceptual entity. A single dataset might be available in more than one representation, with differing schematic layouts, formats, and serializations." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 7 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 10 ;
-            sh:path dlprov:generated_by ],
-        [ sh:class dlprov:Entity ;
-            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 9 ;
-            sh:path dlprov:derived_from ],
-        [ sh:class dlres:IndexedResourcePart ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlres:indexed_parts ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlres:IndexedResourcePartOf ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlres:indexed_part_of ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 8 ;
-            sh:path dlprov:attributed_to ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlprops:short_name ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlprops:title ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 6 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path dlprops:same_as ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlprops:about ] ;
-    sh:targetClass dlres:Dataset .
-
-dlres:Grant a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A grant, typically financial or otherwise quantifiable, of resources." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 7 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 11 ;
-            sh:path dlprov:generated_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlprops:about ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlres:IndexedResourcePartOf ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlres:indexed_part_of ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlprops:same_as ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlprov:Agent ;
-            sh:description "An agent that supports a thing through a pledge, promise, or financial contribution." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 0 ;
-            sh:path dlres:sponsor ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path dlprops:title ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 8 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlres:IndexedResourcePart ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlres:indexed_parts ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 9 ;
-            sh:path dlprov:attributed_to ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlprops:short_name ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:class dlprov:Entity ;
-            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 10 ;
-            sh:path dlprov:derived_from ] ;
-    sh:targetClass dlres:Grant .
-
-dlres:IndexedResourceRelationship a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "An association class for attaching a `name` as additional information to a `hasPart` relationship." ;
+    sh:description "The act of personally making a request to get access to the subject by following some described procedure." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:string ;
-            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
+            sh:description "A free-text account of the subject." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path dlres:locator ],
-        [ sh:class dlres:Resource ;
-            sh:description "Property referencing a resource within an indexed-part or indexed-part-of qualified relationship." ;
+            sh:path dlthings:description ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdf:type ] ;
+    sh:targetClass dlres:PersonalRequest .
+
+dlsocial:Group a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A collection of individual agents. A group may itself play the role of an agent." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprov:acted_on_behalf_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:order 1 ;
-            sh:path dlres:resource ],
-        [ sh:class dlroles:Role ;
-            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
-            sh:nodeKind sh:IRI ;
+            sh:path dlspatial:at_location ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
-            sh:path dlroles:roles ] ;
-    sh:targetClass dlres:IndexedResourceRelationship .
-
-dlres:Instrument a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A thing that enables an agent to perform an action. This is typically a device (e.g., a machine to perform a particular type of measurement), but it can also be a questionnaire that is used to perform a particular kind of assessment. An instrument is typically not a \"reagent\"." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Related mappings"^^xsd:string ;
@@ -755,75 +1424,6 @@ dlres:Instrument a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlprops:title ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path dlprops:same_as ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 10 ;
-            sh:path dlprov:generated_by ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlprops:short_name ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:class dlprov:Entity ;
-            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 9 ;
-            sh:path dlprov:derived_from ],
-        [ sh:class dlres:IndexedResourcePart ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlres:indexed_parts ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -831,67 +1431,105 @@ dlres:Instrument a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 8 ;
             sh:path skos:closeMatch ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 6 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 8 ;
-            sh:path dlprov:attributed_to ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlprops:about ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:class dlres:IndexedResourcePartOf ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
+            sh:name "Is characterized by"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
-            sh:path dlres:indexed_part_of ],
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path rdf:type ],
         [ sh:class dlroles:Relationship ;
             sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 7 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ] ;
-    sh:targetClass dlres:Instrument .
+            sh:order 3 ;
+            sh:path dlroles:qualified_relations ] ;
+    sh:targetClass dlsocial:Group .
 
 dlsocial:Organization a sh:NodeShape ;
     sh:closed true ;
     sh:description "A social or legal instititution such as a company, a society, or a university." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "Name of the subject. A name is closely related to a `title`, but often more compact and identifier-like, but without the implication of uniqueness of an identifier. A name is often used by technical systems to display an item in an organizational structure, such as a file in a directory hierarchy." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlprops:name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlspatial:at_location ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:string ;
             sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
@@ -904,75 +1542,6 @@ dlsocial:Organization a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 3 ;
-            sh:path dlspatial:at_location ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlprov:acted_on_behalf_of ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -980,29 +1549,24 @@ dlsocial:Organization a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 10 ;
             sh:path skos:narrowMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "Name of the subject. A name is closely related to a `title`, but often more compact and identifier-like, but without the implication of uniqueness of an identifier. A name is often used by technical systems to display an item in an organizational structure, such as a file in a directory hierarchy." ;
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlprops:name ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:order 6 ;
+            sh:path rdf:type ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprov:acted_on_behalf_of ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 4 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlroles:qualified_relations ],
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1016,52 +1580,13 @@ dlsocial:Person a sh:NodeShape ;
     sh:closed true ;
     sh:description "Person agents are people, alive, dead, or fictional." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:description "The honorific suffix(es) of the subject's name. For example, generation labels (\"III\"), or indicators of an academic degree, a profession, or a position (\"MD\", \"BA\")." ;
-            sh:group dlsocial:PersonPropertyGroup ;
-            sh:maxCount 1 ;
-            sh:name "Suffix"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlsocial:honorific_name_suffix ],
-        [ sh:datatype xsd:string ;
-            sh:description "The honorific prefix(es) of the subject's name. For example, (academic/formal) titles like \"Mrs\", or \"Dr\", \"Dame\"." ;
-            sh:group dlsocial:PersonPropertyGroup ;
-            sh:maxCount 1 ;
-            sh:name "Title or prefix"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlsocial:honorific_name_prefix ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path rdf:type ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+    sh:property [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1069,36 +1594,13 @@ dlsocial:Person a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 7 ;
             sh:path skos:exactMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "The given (non-inherited) name of the subject." ;
-            sh:group dlsocial:PersonPropertyGroup ;
-            sh:maxCount 1 ;
-            sh:name "Given name"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path dlsocial:given_name ],
-        [ sh:datatype xsd:string ;
-            sh:description "The (inherited) family name of the subject. In many Western languages this is the \"last name\"." ;
-            sh:group dlsocial:PersonPropertyGroup ;
-            sh:maxCount 1 ;
-            sh:name "Family name"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlsocial:family_name ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1111,23 +1613,70 @@ dlsocial:Person a sh:NodeShape ;
             sh:nodeKind sh:IRI ;
             sh:order 1 ;
             sh:path dlprov:acted_on_behalf_of ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
+        [ sh:datatype xsd:string ;
+            sh:description "The honorific suffix(es) of the subject's name. For example, generation labels (\"III\"), or indicators of an academic degree, a profession, or a position (\"MD\", \"BA\")." ;
+            sh:group dlsocial:PersonPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Suffix"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlsocial:honorific_name_suffix ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 4 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:order 2 ;
+            sh:path dlspatial:at_location ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:string ;
+            sh:description "A formatted text corresponding to the name of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlsocial:formatted_name ],
+        [ sh:datatype xsd:string ;
+            sh:description "The (inherited) family name of the subject. In many Western languages this is the \"last name\"." ;
+            sh:group dlsocial:PersonPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Family name"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlsocial:family_name ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 3 ;
-            sh:path dlidentifiers:identifier ],
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:string ;
+            sh:description "The honorific prefix(es) of the subject's name. For example, (academic/formal) titles like \"Mrs\", or \"Dr\", \"Dame\"." ;
+            sh:group dlsocial:PersonPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Title or prefix"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlsocial:honorific_name_prefix ],
         [ sh:class dlthings:Annotation ;
             sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1135,6 +1684,14 @@ dlsocial:Person a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 5 ;
             sh:path dlthings:annotations ],
+        [ sh:datatype xsd:string ;
+            sh:description "The given (non-inherited) name of the subject." ;
+            sh:group dlsocial:PersonPropertyGroup ;
+            sh:maxCount 1 ;
+            sh:name "Given name"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path dlsocial:given_name ],
         [ sh:datatype xsd:string ;
             sh:description "Additional name(s) associated with the subject, such as one or more middle names, or a nick name." ;
             sh:group dlsocial:PersonPropertyGroup ;
@@ -1143,12 +1700,26 @@ dlsocial:Person a sh:NodeShape ;
             sh:order 3 ;
             sh:path dlsocial:additional_names ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
         [ sh:class dlthings:Statement ;
             sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1156,50 +1727,37 @@ dlsocial:Person a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
-        [ sh:datatype xsd:string ;
-            sh:description "A formatted text corresponding to the name of the subject." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlsocial:formatted_name ],
-        [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlspatial:at_location ] ;
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlroles:qualified_relations ] ;
     sh:targetClass dlsocial:Person .
 
 dlsocial:Project a sh:NodeShape ;
     sh:closed true ;
     sh:description "A collective endeavour of some kind. Typically it is a planned process that is undertaken or attempted to meet some requirement, or to achieve a particular goal." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:order 1 ;
+            sh:path dlprops:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:order 8 ;
-            sh:path dlprov:informed_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
+            sh:order 2 ;
+            sh:path dlspatial:at_location ],
         [ sh:datatype w3ctr:NOTE-datetime ;
             sh:description "End is when an activity is deemed to have been ended by some trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
             sh:maxCount 1 ;
@@ -1208,14 +1766,49 @@ dlsocial:Project a sh:NodeShape ;
             sh:path dltemporal:ended_at ;
             sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprov:informed_by ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 4 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
         [ sh:class dlroles:Relationship ;
             sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
@@ -1234,115 +1827,6 @@ dlsocial:Project a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path rdf:type ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:class dlprov:Agent ;
-            sh:description "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 7 ;
-            sh:path dlprov:associated_with ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlprops:short_name ],
-        [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlspatial:at_location ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:datatype w3ctr:NOTE-datetime ;
-            sh:description "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 6 ;
-            sh:path dltemporal:started_at ;
-            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlprops:title ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 4 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ] ;
-    sh:targetClass dlsocial:Project .
-
-dltemporal:InstantaneousEvent a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A moment of a transition from one particular state of the world to another." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path rdf:type ],
-        [ sh:datatype w3ctr:NOTE-datetime ;
-            sh:description "Time at which an instanteneous event takes place or took place." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dltemporal:at_time ;
-            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1350,25 +1834,13 @@ dltemporal:InstantaneousEvent a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 11 ;
             sh:path skos:relatedMatch ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlroles:qualified_relations ],
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1376,35 +1848,25 @@ dltemporal:InstantaneousEvent a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 8 ;
             sh:path skos:closeMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
+        [ sh:class dlprov:Agent ;
+            sh:description "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity." ;
             sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:order 7 ;
+            sh:path dlprov:associated_with ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
             sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
+            sh:order 6 ;
+            sh:path dltemporal:started_at ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
         [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1413,42 +1875,180 @@ dltemporal:InstantaneousEvent a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:path dlthings:pid ] ;
+    sh:targetClass dlsocial:Project .
+
+dltemporal:InstantaneousEvent a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A moment of a transition from one particular state of the world to another." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
         [ sh:class dlthings:Annotation ;
             sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Annotations"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 5 ;
-            sh:path dlthings:annotations ] ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path rdf:type ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Time at which an instanteneous event takes place or took place." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dltemporal:at_time ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlroles:qualified_relations ] ;
     sh:targetClass dltemporal:InstantaneousEvent .
+
+dltemporal:TransientRelationship a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A relationship that is valid or remains in place for a limited time." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Thing ;
+            sh:description "Reference to a `Thing` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path rdf:object ],
+        [ sh:class dlroles:Role ;
+            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlroles:roles ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dltemporal:started_at ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "End is when an activity is deemed to have been ended by some trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dltemporal:ended_at ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path rdf:type ] ;
+    sh:targetClass dltemporal:TransientRelationship .
 
 dlthings:ThingMixin a sh:NodeShape ;
     sh:closed false ;
     sh:description "Mix-in with the common interface of `Thing` and `AttributeSpecification`. This interface enables type specifications (`rdf:type`) for things and attributes via a `type` designator slot to indicate specialized schema classes for validation where a slot's `range` is too generic. A thing or attribute can be further describe with statements on qualified relations to other things (`characterized_by`), or inline attributes (`attributes`). A set of `mappings` slots enables the alignment for arbitrary external schemas and terminologies." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+    sh:property [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 0 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:maxCount 1 ;
+            sh:order 5 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path dlthings:description ],
+            sh:order 4 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:narrowMatch ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:nodeKind sh:Literal ;
             sh:order 2 ;
             sh:path skos:closeMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path rdf:type ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:nodeKind sh:Literal ;
@@ -1459,39 +2059,41 @@ dlthings:ThingMixin a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 8 ;
             sh:path skos:relatedMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:narrowMatch ],
+            sh:order 3 ;
+            sh:path dlthings:description ],
         [ sh:class dlthings:Statement ;
             sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 6 ;
             sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:order 0 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path skos:exactMatch ] ;
+            sh:order 9 ;
+            sh:path rdf:type ] ;
     sh:targetClass dlthings:ThingMixin .
 
 dlthings:ValueSpecification a sh:NodeShape ;
     sh:closed true ;
     sh:description "A `Thing` that is a value of some kind. This class can be used to describe an outcome of a measurement, a factual value or constant, or other qualitative or quantitative information with an associated identifier. If no identifier is available, an `AttributeSpecification` can be used within the context of an associated `Thing` (`attributes`)." ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
         [ sh:class dlthings:Thing ;
             sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1506,13 +2108,21 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 8 ;
             sh:path skos:closeMatch ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
         [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1521,7 +2131,35 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1529,23 +2167,34 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Declares that the value of a `Thing` or `AttributeSpecification` are instances of a particular class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path rdfs:range ],
         [ sh:datatype rdfs:Resource ;
             sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 2 ;
             sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
         [ sh:datatype xsd:string ;
             sh:description "Value of a thing." ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path rdfs:value ] ;
+    sh:targetClass dlthings:ValueSpecification .
+
+dlthings:ValueSpecificationMixin a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Mix-in for a (structured) value specification. Two slots are provided to define a (literal) value (`value`) and its type (`range`)." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
             sh:path rdfs:value ],
@@ -1554,7 +2203,170 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path rdfs:range ],
+            sh:path rdfs:range ] ;
+    sh:targetClass dlthings:ValueSpecificationMixin .
+
+dledist:DataService a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A collection of operations that provides access to one or more dataset distributions or data processing functions." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlres:previous_version ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 14 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlres:version_label ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprops:about ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlprops:keyword ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprops:same_as ],
         [ sh:class dlthings:Statement ;
             sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1562,6 +2374,286 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 12 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:generated_by ] ;
+    sh:targetClass dledist:DataService .
+
+dledist:ElectronicDistribution a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A specific representation of data, which may come in the form of a single file, or an archive or directory of many files, may be standalone or part of a larger collection." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlres:Resource ;
+            sh:description "The resource that the subject is a distribution of." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path dlres:distribution_of ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 6 ;
+            sh:path dlres:access_method ],
+        [ sh:datatype xsd:string ;
+            sh:description "The media type of a distribution as defined by IANA" ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path dledist:media_type ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:class dlthings:Thing ;
+            sh:description "The file format of a distribution." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dledist:format ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 19 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 5 ;
+            sh:path dlprops:about ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:nonNegativeInteger ;
+            sh:description "The size of the subject in bytes." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dledist:byte_size ],
+        [ sh:class dlidentifiers:Checksum ;
+            sh:description "The checksum property provides a mechanism that can be used to verify that the contents of a file or package have not changed." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dledist:checksum ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 20 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 14 ;
+            sh:path dlprops:title ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 13 ;
+            sh:path dlprops:short_name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 12 ;
+            sh:path dlprops:same_as ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 16 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlprops:keyword ],
+        [ sh:class dledist:ElectronicDistribution ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 11 ;
+            sh:path dlres:previous_version ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 22 ;
+            sh:path rdf:type ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 18 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 21 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 15 ;
+            sh:path dlres:version_label ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 17 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ] ;
+    sh:targetClass dledist:ElectronicDistribution .
+
+dlidentifiers:Checksum a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A Checksum is a value that allows to check the integrity of the contents of a file. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Identifies the software agent (algorithm) used to produce the subject `Checksum`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path dlidentifiers:creator ],
+        [ sh:datatype xsd:hexBinary ;
+            sh:description "Lower case hexadecimal encoded checksum digest value." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlidentifiers:notation ;
+            sh:pattern "^[a-fA-F0-9]+$" ] ;
+    sh:targetClass dlidentifiers:Checksum .
+
+dlthings:Property a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An RDF property, a `Thing` used to define a `predicate`, for example in a `Statement`." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
         [ sh:datatype xsd:string ;
             sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1571,42 +2663,359 @@ dlthings:ValueSpecification a sh:NodeShape ;
             sh:order 4 ;
             sh:path dlthings:description ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path rdf:type ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 10 ;
-            sh:path skos:narrowMatch ] ;
-    sh:targetClass dlthings:ValueSpecification .
+            sh:path skos:narrowMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ] ;
+    sh:targetClass dlthings:Property .
 
-dlthings:ValueSpecificationMixin a sh:NodeShape ;
+dlres:Distribution a sh:NodeShape ;
     sh:closed true ;
-    sh:description "Mix-in for a (structured) value specification. Two slots are provided to define a (literal) value (`value`) and its type (`range`)." ;
+    sh:description "A specific representation of a resource, which may come in the form of a physical object, or an electronic file, or an archive or directory of many files, may be standalone or part of a larger collection." ;
+    sh:ignoredProperties ( dledist:media_type dledist:format dledist:byte_size rdf:type dledist:checksum ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlprops:title ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 3 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:derived_from ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 17 ;
+            sh:path dlprov:generated_by ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlprops:about ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 8 ;
+            sh:path dlprops:same_as ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_label ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 6 ;
+            sh:path dlprops:keyword ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 18 ;
+            sh:path rdf:type ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlres:Resource ;
+            sh:description "The resource that the subject is a distribution of." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlres:distribution_of ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 14 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:short_name ],
+        [ sh:class dlres:Distribution ;
+            sh:description "The previous version of the subject in a lineage." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlres:previous_version ] ;
+    sh:targetClass dlres:Distribution .
+
+dlroles:Role a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A role is the function of a resource or agent with respect to a subject, in the context of resource attribution or relationships." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the value of a `Thing` or `AttributeSpecification` are instances of a particular class." ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path rdfs:range ],
-        [ sh:datatype xsd:string ;
-            sh:description "Value of a thing." ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path rdfs:value ] ;
-    sh:targetClass dlthings:ValueSpecificationMixin .
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ] ;
+    sh:targetClass dlroles:Role .
 
-dlthings:Property a sh:NodeShape ;
+dlspatial:Location a sh:NodeShape ;
     sh:closed true ;
-    sh:description "An RDF property, a `Thing` used to define a `predicate`, for example in a `Statement`." ;
+    sh:description "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth." ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:string ;
             sh:description "A free-text account of the subject." ;
@@ -1617,206 +3026,6 @@ dlthings:Property a sh:NodeShape ;
             sh:order 4 ;
             sh:path dlthings:description ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path rdf:type ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ] ;
-    sh:targetClass dlthings:Property .
-
-dlres:Resource a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A consumable, often quantifiable entity, typically made available by a single agent." ;
-    sh:ignoredProperties ( dltemporal:date_modified dltemporal:date_published dlres:sponsor rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 7 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 10 ;
-            sh:path dlprov:generated_by ],
-        [ sh:class dlres:IndexedResourcePart ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of a `hasPart` relationship with a subject (the containing resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlres:indexed_parts ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path dlprops:same_as ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlprops:about ],
-        [ sh:class dlprov:Entity ;
-            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 9 ;
-            sh:path dlprov:derived_from ],
-        [ sh:class dlres:IndexedResourcePartOf ;
-            sh:description "A qualified relation that assigns an index `locator` to a resource within the context of an `isPartOf` relationship with a subject (the contained resource)." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlres:indexed_part_of ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 8 ;
-            sh:path dlprov:attributed_to ],
-        [ sh:datatype xsd:string ;
-            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path dlprops:title ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 6 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:string ;
-            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlprops:short_name ],
-        [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Close mappings"^^xsd:string ;
@@ -1830,6 +3039,66 @@ dlres:Resource a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 0 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
         [ sh:class dlthings:Annotation ;
             sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -1844,210 +3113,36 @@ dlres:Resource a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 10 ;
             sh:path skos:narrowMatch ] ;
-    sh:targetClass dlres:Resource .
+    sh:targetClass dlspatial:Location .
 
-dlroles:Role a sh:NodeShape ;
+dlres:AccessMethod a sh:NodeShape ;
     sh:closed true ;
-    sh:description "A role is the function of a resource or agent with respect to a subject, in the context of resource attribution or relationships." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype rdfs:Resource ;
+    sh:description "An approach or procedure to gain access to the subject." ;
+    sh:ignoredProperties ( dledist:download_url dlthings:description dlres:locator dledist:data_service rdf:type dledist:landing_page ) ;
+    sh:property [ sh:datatype rdfs:Resource ;
             sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ] ;
-    sh:targetClass dlroles:Role .
-
-dlres:IndexedResourcePart a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "An association class for attaching an index `locator` as additional information to a `hasPart` relationship." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlres:Resource ;
-            sh:description "Property referencing a resource within an indexed-part or indexed-part-of qualified relationship." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 1 ;
-            sh:path dlres:resource ],
-        [ sh:class dlroles:Role ;
-            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlroles:roles ],
-        [ sh:datatype xsd:string ;
-            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlres:locator ] ;
-    sh:targetClass dlres:IndexedResourcePart .
-
-dlres:IndexedResourcePartOf a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "An association class for attaching an index `locator` as additional information to a `isPartOf` relationship." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlroles:Role ;
-            sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlroles:roles ],
-        [ sh:class dlres:Resource ;
-            sh:description "Property referencing a resource within an indexed-part or indexed-part-of qualified relationship." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 1 ;
-            sh:path dlres:resource ],
-        [ sh:datatype xsd:string ;
-            sh:description "A descriptive identifier that locates a resource within a containing resource. This can be a unique name, a numerical key, or another notation that uniquely identifies the subject within the containing resource." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlres:locator ] ;
-    sh:targetClass dlres:IndexedResourcePartOf .
+            sh:path rdf:type ] ;
+    sh:targetClass dlres:AccessMethod .
 
 dlprov:Entity a sh:NodeShape ;
     sh:closed true ;
     sh:description "A physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary." ;
-    sh:ignoredProperties ( dlres:indexed_parts dlprops:about dlres:indexed_part_of dlprops:short_name dltemporal:date_modified dltemporal:date_published dlprops:title rdf:type dlprops:same_as dlres:sponsor ) ;
-    sh:property [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:datatype xsd:anyURI ;
+    sh:ignoredProperties ( dlres:version_notes dlres:version_label dlprops:same_as dltemporal:date_published dlres:access_method dlres:distributions dledist:format dledist:byte_size dlprops:about dlres:distribution_of dltemporal:date_modified dlprops:short_name dledist:checksum dlres:sponsor dlprops:keyword dledist:media_type dlres:previous_version dlprops:conforms_to dlprops:title rdf:type ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 10 ;
             sh:path skos:narrowMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 4 ;
-            sh:path dlprov:generated_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
+            sh:order 0 ;
+            sh:path dlidentifiers:identifier ],
         [ sh:class dlprov:Entity ;
             sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
             sh:nodeKind sh:IRI ;
@@ -2059,59 +3154,16 @@ dlprov:Entity a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 5 ;
             sh:path rdf:type ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 0 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlprov:Agent ;
-            sh:description "Attribution is the ascribing of an entity to an agent." ;
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
             sh:nodeKind sh:IRI ;
-            sh:order 2 ;
-            sh:path dlprov:attributed_to ] ;
-    sh:targetClass dlprov:Entity .
-
-dlspatial:Location a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
+            sh:order 4 ;
+            sh:path dlprov:generated_by ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
+            sh:order 1 ;
+            sh:path dlroles:qualified_relations ],
         [ sh:class dlthings:Statement ;
             sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2119,13 +3171,13 @@ dlspatial:Location a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2134,6 +3186,20 @@ dlspatial:Location a sh:NodeShape ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
         [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:maxCount 1 ;
@@ -2141,7 +3207,14 @@ dlspatial:Location a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2149,23 +3222,6 @@ dlspatial:Location a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 8 ;
             sh:path skos:closeMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 0 ;
-            sh:path dlidentifiers:identifier ],
         [ sh:datatype xsd:string ;
             sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2174,52 +3230,37 @@ dlspatial:Location a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 4 ;
             sh:path dlthings:description ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
             sh:order 2 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
+            sh:path dlprov:attributed_to ],
         [ sh:class dlthings:AttributeSpecification ;
             sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Attributes"^^xsd:string ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ] ;
-    sh:targetClass dlspatial:Location .
+            sh:path dlthings:attributes ] ;
+    sh:targetClass dlprov:Entity .
 
 dlprov:Activity a sh:NodeShape ;
     sh:closed true ;
     sh:description "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
     sh:ignoredProperties ( dlprops:title rdf:type dlprops:short_name ) ;
-    sh:property [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+    sh:property [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 0 ;
-            sh:path dlspatial:at_location ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
+            sh:order 7 ;
+            sh:path rdf:type ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
         [ sh:datatype w3ctr:NOTE-datetime ;
             sh:description "End is when an activity is deemed to have been ended by some trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end." ;
             sh:maxCount 1 ;
@@ -2227,99 +3268,6 @@ dlprov:Activity a sh:NodeShape ;
             sh:order 1 ;
             sh:path dltemporal:ended_at ;
             sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Persistent and globally unique identifier of a `Thing`." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:name "Persistent identifier"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Related mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path rdf:type ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype w3ctr:NOTE-datetime ;
-            sh:description "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dltemporal:started_at ;
-            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlroles:qualified_relations ],
-        [ sh:class dlprov:Agent ;
-            sh:description "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 5 ;
-            sh:path dlprov:associated_with ],
-        [ sh:class dlidentifiers:Identifier ;
-            sh:description "An unambiguous reference to the subject within a given context." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlidentifiers:identifier ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Broad mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:broadMatch ],
         [ sh:datatype xsd:string ;
             sh:description "A free-text account of the subject." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2328,38 +3276,20 @@ dlprov:Activity a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 4 ;
             sh:path dlthings:description ],
-        [ sh:class dlprov:Activity ;
-            sh:description "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlprov:informed_by ] ;
-    sh:targetClass dlprov:Activity .
-
-dlprov:Agent a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "Something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity." ;
-    sh:ignoredProperties ( dlsocial:honorific_name_prefix dlsocial:additional_names dlprops:short_name dlsocial:given_name dlsocial:honorific_name_suffix dlprops:name rdf:type dlsocial:formatted_name dlsocial:family_name ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
+        [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Narrow mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 10 ;
             sh:path skos:narrowMatch ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Annotations"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 5 ;
-            sh:path dlthings:annotations ],
-        [ sh:class dlthings:Thing ;
-            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Relations"^^xsd:string ;
-            sh:nodeKind sh:IRI ;
-            sh:order 6 ;
-            sh:path dlthings:relation ],
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
         [ sh:class dlthings:AttributeSpecification ;
             sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2367,6 +3297,13 @@ dlprov:Agent a sh:NodeShape ;
             sh:nodeKind sh:BlankNodeOrIRI ;
             sh:order 3 ;
             sh:path dlthings:attributes ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
         [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2375,15 +3312,33 @@ dlprov:Agent a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:path dlthings:pid ],
+        [ sh:class dlprov:Agent ;
+            sh:description "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 5 ;
+            sh:path dlprov:associated_with ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlprov:informed_by ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
             sh:maxCount 1 ;
-            sh:name "Description"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlspatial:at_location ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlroles:qualified_relations ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2399,35 +3354,137 @@ dlprov:Agent a sh:NodeShape ;
             sh:order 2 ;
             sh:path dlthings:characterized_by ],
         [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Close mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:closeMatch ],
-        [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Related mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 11 ;
             sh:path skos:relatedMatch ],
-        [ sh:class dlspatial:Location ;
-            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Start is when an activity is deemed to have been started by some trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:started_at ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ] ;
+    sh:targetClass dlprov:Activity .
+
+dlres:Resource a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A consumable, often quantifiable entity, typically made available by a single agent." ;
+    sh:ignoredProperties ( dlres:distribution_of dlres:distributions dledist:media_type dledist:format dledist:byte_size rdf:type dledist:checksum dlres:sponsor ) ;
+    sh:property [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:class dlres:Resource ;
+            sh:description "The previous version of the subject in a lineage." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:IRI ;
-            sh:order 1 ;
-            sh:path dlspatial:at_location ],
-        [ sh:class dlroles:Relationship ;
-            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 6 ;
+            sh:path dlres:previous_version ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) changed, updated or modified." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
             sh:order 3 ;
-            sh:path dlroles:qualified_relations ],
+            sh:path dltemporal:date_modified ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype w3ctr:NOTE-datetime ;
+            sh:description "Timepoint at which the subject was (last) published." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dltemporal:date_published ;
+            sh:pattern "^([-+]\\d+)|(\\d{4})|(\\d{4}-[01]\\d)|(\\d{4}-[01]\\d-[0-3]\\d)|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d+([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))|(\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z))$" ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
         [ sh:class dlidentifiers:Identifier ;
             sh:description "An unambiguous reference to the subject within a given context." ;
             sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
+            sh:order 12 ;
             sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:string ;
+            sh:description "A summarily description of the subject. It is closely related to a `name`, but often less compact and more descriptive. Typically used for documents." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path dlprops:title ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares that the subject and an object are equal. Can be used to indicate a URL of a reference Web page that unambiguously indicates the subject's identity. For example, the URL of the subject's Wikipedia page, Wikidata entry, or official website." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 7 ;
+            sh:path dlprops:same_as ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlprov:Entity ;
+            sh:description "Derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 15 ;
+            sh:path dlprov:derived_from ],
+        [ sh:datatype xsd:string ;
+            sh:description "A description of changes between this version and the previous version of the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path dlres:version_notes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlres:AccessMethod ;
+            sh:description "(Alternative) means to gain access to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlres:access_method ],
+        [ sh:class dlprov:Agent ;
+            sh:description "Attribution is the ascribing of an entity to an agent." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 14 ;
+            sh:path dlprov:attributed_to ],
+        [ sh:class dlprov:Activity ;
+            sh:description "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 16 ;
+            sh:path dlprov:generated_by ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2435,23 +3492,193 @@ dlprov:Agent a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 7 ;
             sh:path skos:exactMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A relation of an information artifact to the subject, such as a URL identifying the topic of a document." ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlprops:about ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:string ;
+            sh:description "Version indicator (name or identifier) of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path dlres:version_label ],
+        [ sh:class dlthings:Thing ;
+            sh:description "An established standard to which the subject conforms." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 2 ;
+            sh:path dlprops:conforms_to ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 17 ;
+            sh:path rdf:type ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 13 ;
+            sh:path dlroles:qualified_relations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "One or more keywords or tags describing the subject." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path dlprops:keyword ],
+        [ sh:datatype xsd:string ;
+            sh:description "A shortened name for the subject. For example, an acronym, initialism, nickname, or other abbreviation of the `name`." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path dlprops:short_name ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ] ;
+    sh:targetClass dlres:Resource .
+
+dlprov:Agent a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "Something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity." ;
+    sh:ignoredProperties ( dlsocial:honorific_name_prefix dlsocial:given_name dlprops:name dlsocial:formatted_name dlprops:short_name dlsocial:additional_names rdf:type dlsocial:family_name dlsocial:honorific_name_suffix ) ;
+    sh:property [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
         [ sh:datatype rdfs:Resource ;
             sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
             sh:order 4 ;
             sh:path rdf:type ],
+        [ sh:class dlthings:Thing ;
+            sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Relations"^^xsd:string ;
+            sh:nodeKind sh:IRI ;
+            sh:order 6 ;
+            sh:path dlthings:relation ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Close mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Persistent and globally unique identifier of a `Thing`." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "Persistent identifier"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:pid ],
+        [ sh:class dlidentifiers:Identifier ;
+            sh:description "An unambiguous reference to the subject within a given context." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlidentifiers:identifier ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlroles:Relationship ;
+            sh:description "Characterizes the relationship or role of an entity with respect to the subject." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlroles:qualified_relations ],
         [ sh:class dlprov:Agent ;
             sh:description "Assign the authority and responsibility for carrying out a specific activity of the subject agent to another agent." ;
             sh:nodeKind sh:IRI ;
             sh:order 0 ;
-            sh:path dlprov:acted_on_behalf_of ] ;
+            sh:path dlprov:acted_on_behalf_of ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Related mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path skos:relatedMatch ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Annotations"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 5 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Broad mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:maxCount 1 ;
+            sh:name "Description"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:class dlspatial:Location ;
+            sh:description "Associate the subject with a location. This can be a geographic place, or a place in a directory, or table." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path dlspatial:at_location ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ] ;
     sh:targetClass dlprov:Agent .
 
 dlidentifiers:Identifier a sh:NodeShape ;
     sh:closed true ;
     sh:description "An identifier is a label that uniquely identifies an item in a particular context. Some identifiers are globally unique. All identifiers are unique within their individual scope." ;
-    sh:ignoredProperties ( dlidentifiers:schema_agency rdf:type ) ;
+    sh:ignoredProperties ( rdf:type dlidentifiers:schema_agency ) ;
     sh:property [ sh:datatype xsd:anyURI ;
             sh:description "An agent responsible for making an entity." ;
             sh:maxCount 1 ;
@@ -2476,26 +3703,146 @@ dlidentifiers:Identifier a sh:NodeShape ;
 dlroles:Relationship a sh:NodeShape ;
     sh:closed true ;
     sh:description "An association class for characterizing the relation between two things with the role(s) the object had with respect to the subject. A relationship is always between two things only, but can be annotated with multiple roles (for example, a person having both an author role with respect to a dataset, and also being the person who is legally responsible contact for it)." ;
-    sh:ignoredProperties ( rdf:type ) ;
+    sh:ignoredProperties ( rdf:type dltemporal:started_at dlres:locator dltemporal:ended_at ) ;
     sh:property [ sh:class dlroles:Role ;
             sh:description "Describes the function of an entity or agent (object) within the scope of a `Relationship` with the subject." ;
-            sh:minCount 1 ;
             sh:nodeKind sh:IRI ;
             sh:order 1 ;
             sh:path dlroles:roles ],
-        [ sh:datatype xsd:anyURI ;
+        [ sh:class dlthings:Thing ;
             sh:description "Reference to a `Thing` within a `Statement`." ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
+            sh:nodeKind sh:IRI ;
             sh:order 0 ;
-            sh:path rdf:object ] ;
+            sh:path rdf:object ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path rdf:type ] ;
     sh:targetClass dlroles:Relationship .
+
+dlthings:Annotation a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "A tag/value pair with the semantics of OWL Annotation." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description "The actual annotation." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 1 ;
+            sh:path dlthings:annotation_value ],
+        [ sh:class dlthings:Thing ;
+            sh:description "A tag identifying an annotation." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path dlthings:annotation_tag ] ;
+    sh:targetClass dlthings:Annotation .
+
+dlthings:AttributeSpecification a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An attribute is conceptually a thing, but it requires no dedicated identifier (`pid`). Instead, it is linked to a `Thing` via its `attributes` slot and declares a `predicate` on the nature of the relationship." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 7 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 6 ;
+            sh:path dlthings:attributes ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "Declares that the value of a `Thing` or `AttributeSpecification` are instances of a particular class." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 11 ;
+            sh:path rdfs:range ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 9 ;
+            sh:path skos:relatedMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path skos:broadMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "A free-text account of the subject." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 4 ;
+            sh:path dlthings:description ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path rdf:type ],
+        [ sh:class dlthings:Property ;
+            sh:description "Reference to a `Property` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path rdf:predicate ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 5 ;
+            sh:path skos:exactMatch ],
+        [ sh:datatype xsd:string ;
+            sh:description "Value of a thing." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 12 ;
+            sh:path rdfs:value ],
+        [ sh:class dlthings:Annotation ;
+            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 1 ;
+            sh:path dlthings:annotations ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path skos:closeMatch ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:nodeKind sh:Literal ;
+            sh:order 8 ;
+            sh:path skos:narrowMatch ] ;
+    sh:targetClass dlthings:AttributeSpecification .
+
+dlthings:Statement a sh:NodeShape ;
+    sh:closed true ;
+    sh:description "An RDF statement that links a `predicate` (a `Property`) with an `object` (a `Thing`) to the subject to form a triple. A `Statement` is used to qualify a relation to a `Thing` referenced by its identifier. For specifying a qualified relation to an attribute that has no dedicated identifier, use an `AttributeSpecification`." ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:class dlthings:Thing ;
+            sh:description "Reference to a `Thing` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 0 ;
+            sh:path rdf:object ],
+        [ sh:class dlthings:Property ;
+            sh:description "Reference to a `Property` within a `Statement`." ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:IRI ;
+            sh:order 1 ;
+            sh:path rdf:predicate ] ;
+    sh:targetClass dlthings:Statement .
 
 dlthings:Thing a sh:NodeShape ;
     sh:closed true ;
-    sh:description "The most basic, identifiable item. In addition to the slots that are common between a `Thing` and an `AttributeSpecification` (see `ThingMixin`), two additional slots are provided. The `id` slot takes the required identifier for a `Thing`. The `relation` slot allows for the inline specification of other `Thing` instances. Such a relation is unqualified (and symmetric), and should be further characterized via a `Statement` (see `characterized_by`). From a schema perspective, the `relation` slots allows for building self-contained, structured documents (e.g., a JSON object) with arbitrarily complex information on a `Thing`." ;
-    sh:ignoredProperties ( dlprov:attributed_to dltemporal:at_time dlres:indexed_part_of dltemporal:date_published rdf:type dlsocial:formatted_name dlprov:associated_with dltemporal:started_at dlsocial:additional_names dlroles:qualified_relations dlprops:short_name dlsocial:given_name dltemporal:date_modified dlsocial:honorific_name_suffix rdfs:range dlsocial:family_name dlprops:same_as dlprov:generated_by rdfs:value dltemporal:ended_at dlprov:informed_by dlprops:name dlidentifiers:identifier dlprov:derived_from dlspatial:at_location dlres:indexed_parts dlsocial:honorific_name_prefix dlprops:about dlprops:title dlres:sponsor dlprov:acted_on_behalf_of ) ;
+    sh:description "The most basic, identifiable item. In addition to the slots that are common between a `Thing` and an `AttributeSpecification` (see `ThingMixin`), two additional slots are provided. The `pid` slot takes the required identifier for a `Thing`. The `relation` slot allows for the inline specification of other `Thing` instances. Such a relation is unqualified (and symmetric), and should be further characterized via a `Statement` (see `characterized_by`). From a schema perspective, the `relation` slots allows for building self-contained, structured documents (e.g., a JSON object) with arbitrarily complex information on a `Thing`." ;
+    sh:ignoredProperties ( dlsocial:honorific_name_prefix dlprov:generated_by dlres:version_notes dlres:version_label dlprops:same_as dltemporal:date_published dlroles:qualified_relations dlprov:informed_by rdfs:range dlprov:acted_on_behalf_of dlsocial:given_name dlres:access_method dlres:distributions dledist:format dlprov:derived_from dledist:byte_size dlprops:about dltemporal:started_at dlsocial:family_name dlprov:attributed_to dlres:distribution_of dltemporal:at_time dltemporal:date_modified dlprops:short_name dlsocial:formatted_name dlprov:associated_with dlsocial:additional_names dledist:checksum dlidentifiers:identifier dlres:sponsor rdfs:value dlsocial:honorific_name_suffix dlprops:keyword dlspatial:at_location dlprops:name dledist:media_type dltemporal:ended_at dlres:previous_version dlprops:conforms_to dlprops:title rdf:type ) ;
     sh:property [ sh:datatype xsd:anyURI ;
             sh:description "Persistent and globally unique identifier of a `Thing`." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2504,7 +3851,14 @@ dlthings:Thing a sh:NodeShape ;
             sh:name "Persistent identifier"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
-            sh:path dlthings:id ],
+            sh:path dlthings:pid ],
+        [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Exact mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 7 ;
+            sh:path skos:exactMatch ],
         [ sh:class dlthings:Thing ;
             sh:description "Declares an unqualified relation of the subject `Thing` to another `Thing`. This schema slot is used to define related things inline. If such a definition is not needed. A qualified relationship can be declared directly using the `characterized_by` slot." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2512,27 +3866,6 @@ dlthings:Thing a sh:NodeShape ;
             sh:nodeKind sh:IRI ;
             sh:order 6 ;
             sh:path dlthings:relation ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Narrow mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path skos:narrowMatch ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Is characterized by"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 2 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Attributes"^^xsd:string ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 3 ;
-            sh:path dlthings:attributes ],
         [ sh:class dlthings:Annotation ;
             sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2549,12 +3882,39 @@ dlthings:Thing a sh:NodeShape ;
             sh:order 4 ;
             sh:path dlthings:description ],
         [ sh:datatype xsd:anyURI ;
+            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Narrow mappings"^^xsd:string ;
+            sh:nodeKind sh:Literal ;
+            sh:order 10 ;
+            sh:path skos:narrowMatch ],
+        [ sh:class dlthings:Statement ;
+            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Is characterized by"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 2 ;
+            sh:path dlthings:characterized_by ],
+        [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
             sh:name "Broad mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 9 ;
             sh:path skos:broadMatch ],
+        [ sh:datatype rdfs:Resource ;
+            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path rdf:type ],
+        [ sh:class dlthings:AttributeSpecification ;
+            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
+            sh:group "ThingsPropertyGroup"^^xsd:string ;
+            sh:name "Attributes"^^xsd:string ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:order 3 ;
+            sh:path dlthings:attributes ],
         [ sh:datatype xsd:anyURI ;
             sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
             sh:group "ThingsPropertyGroup"^^xsd:string ;
@@ -2568,137 +3928,7 @@ dlthings:Thing a sh:NodeShape ;
             sh:name "Related mappings"^^xsd:string ;
             sh:nodeKind sh:Literal ;
             sh:order 11 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:group "ThingsPropertyGroup"^^xsd:string ;
-            sh:name "Exact mappings"^^xsd:string ;
-            sh:nodeKind sh:Literal ;
-            sh:order 7 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path rdf:type ] ;
+            sh:path skos:relatedMatch ] ;
     sh:targetClass dlthings:Thing .
-
-dlthings:Annotation a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "A tag/value pair with the semantics of OWL Annotation." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:anyURI ;
-            sh:description "A tag identifying an annotation." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path dlthings:annotation_tag ],
-        [ sh:datatype xsd:string ;
-            sh:description "The actual annotation." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 1 ;
-            sh:path dlthings:annotation_value ] ;
-    sh:targetClass dlthings:Annotation .
-
-dlthings:AttributeSpecification a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "An attribute is conceptually a thing, but it requires no dedicated identifier (`id`). Instead, it is linked to a `Thing` via its `attributes` slot and declares a `predicate` on the nature of the relationship." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Property ;
-            sh:description "Reference to a `Property` within a `Statement`." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 0 ;
-            sh:path rdf:predicate ],
-        [ sh:class dlthings:Statement ;
-            sh:description "Qualifies relationships between a subject `Thing` and an object `Thing` with a `Statement` declaring a `predicate` on the nature of the relationship." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 7 ;
-            sh:path dlthings:characterized_by ],
-        [ sh:class dlthings:AttributeSpecification ;
-            sh:description "Declares a relation that associates a `Thing` (or another attribute) with an attribute, where an attribute is an intrinsic characteristic, such as a quality, capability, disposition, function, or is an externally derived attribute determined from some descriptor (e.g. a quantity, position, label/identifier). Technically, this declaration is done via an `AttributeSpecification` that combines a `predicate` with a value declaration and the attribute-related slots of a `Thing`. Importantly, such attributes are declared inline, because they do not have a unique identifier. If an identifier is available, a `Thing` declaration (see `relation`), and a qualification of that relationship via a `Statement` (see `characterized_by`) should be preferred." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 6 ;
-            sh:path dlthings:attributes ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have broader meaning." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path skos:broadMatch ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Declares that the value of a `Thing` or `AttributeSpecification` are instances of a particular class." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 11 ;
-            sh:path rdfs:range ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have related meaning." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 9 ;
-            sh:path skos:relatedMatch ],
-        [ sh:datatype rdfs:Resource ;
-            sh:description "State that the subject is an instance of a particular schema class. Typically, no explicit value needs to be assigned to this slot, because it matches the class type of a particular record. However, this slots can be used as a type designator of a schema element for validation and schema structure handling purposes. This is used to indicate specialized schema classes for properties that accept a hierarchy of classes as their range." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 10 ;
-            sh:path rdf:type ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have narrower meaning." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 8 ;
-            sh:path skos:narrowMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "A free-text account of the subject." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 4 ;
-            sh:path dlthings:description ],
-        [ sh:class dlthings:Annotation ;
-            sh:description "A record of properties of the metadata record on a subject, a collection of tag/text tuples with the semantics of OWL Annotation." ;
-            sh:nodeKind sh:BlankNodeOrIRI ;
-            sh:order 1 ;
-            sh:path dlthings:annotations ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have identical meaning." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 5 ;
-            sh:path skos:exactMatch ],
-        [ sh:datatype xsd:string ;
-            sh:description "Value of a thing." ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 12 ;
-            sh:path rdfs:value ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "A list of terms from different schemas or terminology systems that have close meaning." ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path skos:closeMatch ] ;
-    sh:targetClass dlthings:AttributeSpecification .
-
-dlthings:Statement a sh:NodeShape ;
-    sh:closed true ;
-    sh:description "An RDF statement that links a `predicate` (a `Property`) with an `object` (a `Thing`) to the subject to form a triple. A `Statement` is used to qualify a relation to a `Thing` referenced by its identifier. For specifying a qualified relation to an attribute that has no dedicated identifier, use an `AttributeSpecification`." ;
-    sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:class dlthings:Property ;
-            sh:description "Reference to a `Property` within a `Statement`." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:IRI ;
-            sh:order 1 ;
-            sh:path rdf:predicate ],
-        [ sh:datatype xsd:anyURI ;
-            sh:description "Reference to a `Thing` within a `Statement`." ;
-            sh:maxCount 1 ;
-            sh:minCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path rdf:object ] ;
-    sh:targetClass dlthings:Statement .
 
 

--- a/tools/fetch_data.sh
+++ b/tools/fetch_data.sh
@@ -1,0 +1,40 @@
+#!/bin/zsh
+
+# Check for input arguments
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <source_directory> <output_file>"
+  exit 1
+fi
+
+SOURCE_DIR="$1"
+OUTPUT_FILE="$2"
+
+# Temporary files
+TMP_ALL_CONTENT=$(mktemp)
+TMP_PREFIXES=$(mktemp)
+TMP_REST=$(mktemp)
+
+# Process each .rdf file (excluding .rdf.tmp)
+find "$SOURCE_DIR" -type f -name '*.rdf' ! -name '*.rdf.tmp' | while read -r FILE; do
+  if grep -q 'PRINTING N3 GRAPH' "$FILE"; then
+    # This deals with files with errors in them; still outputs duplicate statements though; TODO
+    awk '/PRINTING N3 GRAPH/ {found=1; next} found' "$FILE" >> "$TMP_ALL_CONTENT"
+  else
+    # If no error, just concatenate entire file
+    cat "$FILE" >> "$TMP_ALL_CONTENT"
+  fi
+done
+
+# Extract unique @prefix lines
+grep '^@prefix' "$TMP_ALL_CONTENT" | sort | uniq > "$TMP_PREFIXES"
+
+# Extract all other lines
+grep -v '^@prefix' "$TMP_ALL_CONTENT" > "$TMP_REST"
+
+# Combine and write to output
+cat "$TMP_PREFIXES" "$TMP_REST" > "$OUTPUT_FILE"
+
+# Clean up
+rm "$TMP_ALL_CONTENT" "$TMP_PREFIXES" "$TMP_REST"
+
+echo "Processed RDF content written to: $OUTPUT_FILE"

--- a/tools/fetch_schemas.sh
+++ b/tools/fetch_schemas.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+
+# File containing the list of class names
+NAMES_FILE="schema_names.txt"
+
+# Output directory
+OUTPUT_DIR="./schemas"
+
+# Base URL
+BASE_URL="https://concepts.datalad.org/s"
+
+# File types to fetch
+EXTENSIONS=("shacl.ttl" "owl.ttl")
+
+# Create the output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Read each class name and fetch corresponding content for shacl and owl
+while IFS= read -r name || [[ -n "$name" ]]; do
+  if [[ -n "$name" ]]; then
+    for ext in "${EXTENSIONS[@]}"; do
+      url="${BASE_URL}/${name}/unreleased.${ext}"
+      output_file="${OUTPUT_DIR}/${name}.${ext}"
+      echo "Fetching: $url -> $output_file"
+      curl -s "$url" -o "$output_file"
+    done
+  fi
+done < "$NAMES_FILE"
+
+echo "All files downloaded to '$OUTPUT_DIR'"


### PR DESCRIPTION
This is an interim solution in the form of shell scripts to fetch datalad-concepts exports (shacl, owl) and to convert example data to rdf, to allow using all of those as the default files for a shacl-vue deployment. The ideal is to rather create a single base schema in yaml, similar to the standard that we have followed in other use cases e.g. trr379, inm7, etc, and to update the make files that generate the schemas and data from there.