### PR TITLE
New config options and more for improved display

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -25,8 +25,11 @@
         }
     },
     "id_iri": "https://concepts.datalad.org/s/things/v1/pid",
+    "id_autogenerate": {},
     "show_shapes_wo_id": false,
     "show_all_fields": true,
+    "hide_classes": [],
+    "class_name_display": "name",
     "use_service": false,
     "use_token": false,
     "token_info": false,

--- a/src/components/EmailEditor.vue
+++ b/src/components/EmailEditor.vue
@@ -1,0 +1,75 @@
+<template>
+    <v-input
+        v-model="internalValue"
+        :rules="rules"
+        ref="fieldRef"
+        :id="inputId"
+        hide-details="auto"
+        style="margin-bottom: 1em;"
+    >
+        <v-text-field
+            v-model="subValues.email"
+            density="compact"
+            variant="outlined"
+            label="add email"
+            hide-details="auto"
+        >
+        </v-text-field>
+    </v-input>
+</template>
+
+<script setup>
+    import { useRules } from '../composables/rules'
+    import { useRegisterRef } from '../composables/refregister';
+    import { useBaseInput } from '@/composables/base';
+
+    const props = defineProps({
+        modelValue: String,
+        property_shape: Object,
+        node_uid: String,
+        node_idx: String,
+        triple_uid: String,
+        triple_idx: Number
+    })
+    const { rules } = useRules(props.property_shape)
+    const inputId = `input-${Date.now()}`;
+    const { fieldRef } = useRegisterRef(inputId, props);
+    const emit = defineEmits(['update:modelValue']);
+    const { subValues, internalValue } = useBaseInput(
+        props,
+        emit,
+        valueParser,
+        valueCombiner
+    );
+
+    function valueParser(value) {
+        // Parsing internalValue into ref values for separate subcomponent(s)
+        return {
+            email: value,
+        }
+    }
+
+    function valueCombiner(values) {
+        // Determine internalValue from subvalues/subcomponents
+        return values.email
+    }
+
+</script>
+
+<script>
+    import { SHACL, DLTYPES } from '../modules/namespaces'
+    export const matchingLogic = (shape) => {
+        // sh:nodeKind exists
+        if ( shape.hasOwnProperty(SHACL.nodeKind.value) ) {
+            // sh:nodeKind == sh:Literal
+            if ( shape[SHACL.nodeKind.value] == SHACL.Literal.value ) {
+                // sh:datatype exists
+                if ( shape.hasOwnProperty(SHACL.datatype.value) ) {
+                    // sh:datatype == dltypes:EmailAddress
+                    return shape[SHACL.datatype.value] == DLTYPES.EmailAddress.value
+                }
+            }
+        }
+        return false
+    };
+</script>

--- a/src/components/FormEditor.vue
+++ b/src/components/FormEditor.vue
@@ -1,7 +1,7 @@
 <template>
   <v-sheet class="pa-4 scaled-sheet" border rounded elevation="2">
     <div style="display: flex; position: relative; ">
-      <h3>{{ toCURIE(localShapeIri, allPrefixes) }}</h3>
+      <h3>{{ getDisplayName(localShapeIri, configVarsMain, allPrefixes) }}</h3>
 
       <div style="display: flex; margin-left: auto;">
             <v-btn
@@ -68,7 +68,7 @@
   import { ref, onMounted, onBeforeMount, onBeforeUnmount, provide, inject, reactive, computed, toRaw} from 'vue'
   import { SHACL } from '../modules/namespaces'
   import { toCURIE } from 'shacl-tulip'
-  import { addCodeTagsToText } from '../modules/utils';
+  import { addCodeTagsToText, getDisplayName} from '../modules/utils';
 
   // ----- //
   // Props //
@@ -100,6 +100,7 @@
   const formValid = ref(null)
   const fieldMap = reactive({}); // Maps element IDs to human-readable labels
   const validationErrors = ref([]);
+  const configVarsMain = inject('configVarsMain')
 
   function registerRef(id, fieldData) {
     fieldMap[id] = fieldData;

--- a/src/components/NodeShapeEditor.vue
+++ b/src/components/NodeShapeEditor.vue
@@ -25,14 +25,14 @@
         </v-card>
     </span>
     <span v-else>
-        <h3>Properties from: {{ toCURIE(localShapeIri, allPrefixes) }}</h3>
+        <h3>Properties from: <code class="code-style">{{ getDisplayName(localShapeIri, configVarsMain, allPrefixes) }}</code></h3>
         <br>
         <span v-for="property in classProperties[localShapeIri]" :key="localShapeIri + '-' + localNodeIdx + '-' + property">
             <PropertyShapeEditor :property_shape="propertyShapes[property]" :node_uid="localShapeIri" :node_idx="localNodeIdx"/>
         </span>
         
         <span v-for="c in superClasses[localShapeIri]">
-            <h3>Properties from: {{ toCURIE(c, allPrefixes) }}</h3>
+            <h3>Properties from: <code class="code-style">{{ getDisplayName(c, configVarsMain, allPrefixes) }}</code></h3>
             <br>
             <span v-for="property in classProperties[c]" :key="localShapeIri + '-' + localNodeIdx + '-' + property[SHACL.path.value]">
                 <PropertyShapeEditor :property_shape="propertyShapes[property]" :node_uid="localShapeIri" :node_idx="localNodeIdx"/>
@@ -60,8 +60,7 @@
 <script setup>
     import { ref, onBeforeUpdate, onBeforeMount, onBeforeUnmount, onMounted, inject, shallowRef} from 'vue'
     import {SHACL, RDF, RDFS, DLTHING} from '../modules/namespaces'
-    import { orderArrayOfObjects } from '../modules/utils';
-    import {toCURIE, toIRI} from 'shacl-tulip'
+    import { orderArrayOfObjects, getDisplayName} from '../modules/utils';
 
     // ----- //
     // Props //
@@ -83,6 +82,7 @@
     const shapesDS = inject('shapesDS')
     const superClasses = inject('superClasses')
     const allPrefixes = inject('allPrefixes')
+    const configVarsMain = inject('configVarsMain')
     const shape_obj = shapesDS.data.nodeShapes[localShapeIri.value]
     const ready = ref(false)
     var tab = ref(null)

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -115,7 +115,7 @@
                         new_id_val += allPrefixes[cfg["id_autogenerate_prefix"]]
                     }
                 }
-                // Then preprend
+                // Then prepend
                 if (cfg["id_autogenerate_prepend"]) {
                     new_id_val += cfg["id_autogenerate_prepend"]
                 }

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-row align="start" no-gutters v-if="formData.content[localNodeUid] && show_field">
+    <v-row align="start" no-gutters v-if="formData.content[localNodeUid] && show_field" :class="compDisabled ? 'disabled-row' : ''">
         <v-col cols="4">
             <span>{{ nameOrCURIE(localPropertyShape, shapesDS.data.prefixes, true) }}<span v-if="isRequired" style="color: red;"> *</span>:
                 <v-tooltip activator="parent" location="right" max-width="400px" max-height="400px">
@@ -21,6 +21,7 @@
                                 :node_idx="localNodeIdx"
                                 :triple_uid="my_uid"
                                 :triple_idx="triple_idx"
+                                :disabled="compDisabled"
                                 >
                             </component>
                         </Suspense>
@@ -34,6 +35,7 @@
                                 icon="mdi-delete-outline"
                                 @click="formData.removeObject(localNodeUid, localNodeIdx, my_uid, triple_idx)"
                                 density="comfortable"
+                                :disabled="compDisabled"
                             ></v-btn>
                             &nbsp;
                             <!-- Add button -->
@@ -43,6 +45,7 @@
                                 icon="mdi-plus-circle-outline"
                                 @click="formData.addObject(localNodeUid, localNodeIdx, my_uid)"
                                 density="comfortable"
+                                :disabled="compDisabled"
                             ></v-btn>
                     </v-col>
                 </v-row>
@@ -55,7 +58,7 @@
     import { ref, onMounted, onBeforeMount, computed, inject, onBeforeUpdate, onBeforeUnmount, watch, toRaw} from 'vue'
     import { SHACL } from '../modules/namespaces'
     import { useRules } from '../composables/rules'
-    import { nameOrCURIE, addCodeTagsToText} from '../modules/utils';
+    import { nameOrCURIE, addCodeTagsToText, isObject} from '../modules/utils';
     
     // ----- //
     // Props //
@@ -81,18 +84,53 @@
     const defaultEditor = inject('defaultEditor');
     const formData = inject('formData');
     const shapesDS = inject('shapesDS');
+    const allPrefixes = inject('allPrefixes');
     const show_all_fields = inject('show_all_fields');
     const { isRequired } = useRules(localPropertyShape.value)
+    const configVarsMain = inject('configVarsMain')
+    const ID_IRI = inject('ID_IRI');
+    const compDisabled = ref(false)
 
     // ----------------- //
     // Lifecycle methods //
     // ----------------- //
 
     onMounted(() => {
-        if (formData.content[localNodeUid.value][localNodeIdx.value][my_uid.value]) {
-            return;
+        // Autogenerate value for idi_iri if required
+        if (my_uid.value == ID_IRI.value &&
+            isObject(configVarsMain.idAutogenerate) &&
+            Object.keys(configVarsMain.idAutogenerate).includes(localNodeUid.value)
+        ) {
+            // if the object value is already in formdata, dont autogenerate and don't add,
+            // but still disable the field
+            if (formData.content[localNodeUid.value][localNodeIdx.value][my_uid.value]) {
+                compDisabled.value = true
+                return;
+            } else {
+                var new_id_val = ""
+                var cfg = configVarsMain.idAutogenerate[localNodeUid.value]
+                // Start with prefix uri
+                if (cfg["id_autogenerate_prefix"]) {
+                    if (allPrefixes.hasOwnProperty(cfg["id_autogenerate_prefix"])) {
+                        new_id_val += allPrefixes[cfg["id_autogenerate_prefix"]]
+                    }
+                }
+                // Then preprend
+                if (cfg["id_autogenerate_prepend"]) {
+                    new_id_val += cfg["id_autogenerate_prepend"]
+                }
+                // then random uuid
+                new_id_val += crypto.randomUUID()
+                // then add to formdata
+                formData.addPredicate(localNodeUid.value, localNodeIdx.value, my_uid.value, [new_id_val])
+                compDisabled.value = true
+            }
+        } else {
+            if (formData.content[localNodeUid.value][localNodeIdx.value][my_uid.value]) {
+                return;
+            }
+            formData.addPredicate(localNodeUid.value, localNodeIdx.value, my_uid.value)
         }
-        formData.addPredicate(localNodeUid.value, localNodeIdx.value, my_uid.value)
     })
 
 
@@ -174,6 +212,15 @@
 
 
 </script>
+
+<style scoped>
+
+    .disabled-row {
+        opacity: 0.5;
+        /* color: grey; */
+    }
+
+</style>
 
 
 <style>

--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -15,7 +15,7 @@
                                 <v-list-item  value="data"><h4>Data Types</h4></v-list-item>
                                 <!-- <v-text-field variant="outlined" append-inner-icon="mdi-magnify" density="compact"></v-text-field> -->
                                 <v-list-item
-                                    v-for="node in idFilteredNodeShapeNames"
+                                    v-for="node in filteredNodeShapeNames"
                                     :prepend-icon="getClassIcon(shapesDS.data.nodeShapeNames[node])"
                                     :title="node"
                                     @click="selectType(shapesDS.data.nodeShapeNames[node], true)">
@@ -33,7 +33,7 @@
                                         
                                         <span v-if="selectedIRI">
                                             <h2 class="mx-4 mb-4 truncate-heading">
-                                                {{ toCURIE(selectedIRI, allPrefixes) }}
+                                                {{ getDisplayName(selectedIRI, configVarsMain, allPrefixes) }}
                                                 &nbsp;&nbsp; <v-btn icon="mdi-plus" size="x-small" variant="tonal" @click="addInstanceItem()"></v-btn>
                                             </h2>
 
@@ -66,7 +66,7 @@
                                                 :value="'panel' + (i+1).toString()"
                                                 :disabled="f.disabled"
                                             >
-                                                <v-expansion-panel-title> <h2><em>Editing: {{ toCURIE(f.shapeIRI, allPrefixes) }} </em></h2></v-expansion-panel-title>
+                                                <v-expansion-panel-title> <h2><em>Editing: {{ getDisplayName(f.shapeIRI, configVarsMain, allPrefixes) }} </em></h2></v-expansion-panel-title>
                                                 <v-expansion-panel-text density="compact">
                                                     <span v-if="idRecordLoading">
                                                         <v-skeleton-loader type="list-item-avatar"></v-skeleton-loader>
@@ -108,7 +108,7 @@
 <script setup>
     import { effect, ref, computed, provide, watch, reactive, onBeforeUpdate, nextTick, toRaw} from 'vue'
     import { useConfig } from '@/composables/configuration';
-    import { adjustHexColor, findObjectByKey, addCodeTagsToText, getSuperClasses} from '../modules/utils';
+    import { adjustHexColor, findObjectByKey, addCodeTagsToText, getSuperClasses, getDisplayName} from '../modules/utils';
     import {toCURIE, toIRI} from 'shacl-tulip'
     import editorMatchers from '@/modules/editors';
     import defaultEditor from '@/components/UnknownEditor.vue';
@@ -299,6 +299,20 @@
                 SHACL.path.value,
                 ID_IRI.value)
             ) {
+                shapeNames.push(n)
+            }
+        }
+        return shapeNames
+    })
+    const filteredNodeShapeNames = computed(() =>{
+        var names = idFilteredNodeShapeNames.value
+        console.log(names)
+        if (configVarsMain.hideClasses.length == 0) {
+            return names
+        }
+        var shapeNames = []
+        for (var n of names) {
+            if (configVarsMain.hideClasses.indexOf(shapesDS.data.nodeShapeNames[n]) < 0) {
                 shapeNames.push(n)
             }
         }

--- a/src/composables/configuration.js
+++ b/src/composables/configuration.js
@@ -9,6 +9,8 @@ const basePath = import.meta.env.BASE_URL || '/';
 
 const mainVarsToLoad = {
     "show_shapes_wo_id": true,
+    "hide_classes": [],
+    "id_autogenerate": {},
     "prefixes": {},
     "class_icons": {},
     "app_name": "shacl-vue",
@@ -22,7 +24,8 @@ const mainVarsToLoad = {
         "logo": "shacl_vue_logo.svg",
     },
     "use_token": false,
-    "use_service": false
+    "use_service": false,
+    "class_name_display": "name"
 }
 
 export function useConfig(url) {

--- a/src/modules/namespaces.js
+++ b/src/modules/namespaces.js
@@ -9,4 +9,6 @@ export const XSD = rdf.namespace('http://www.w3.org/2001/XMLSchema#');
 export const DLDIST = rdf.namespace('https://concepts.datalad.org/s/distribution/unreleased/');
 export const DLTHING = rdf.namespace('https://concepts.datalad.org/s/thing/unreleased/');
 export const DLTHINGS = rdf.namespace('https://concepts.datalad.org/s/things/v1/');
+export const DLTYPES = rdf.namespace('https://concepts.datalad.org/s/types/unreleased/');
 export const DLCO = rdf.namespace('https://concepts.datalad.org/');
+export const SKOS = rdf.namespace('http://www.w3.org/2004/02/skos/core#');

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -1,4 +1,4 @@
-import { SHACL, RDFS, DLTHINGS} from '../modules/namespaces'
+import { SHACL, RDFS, DLTHINGS, SKOS} from '../modules/namespaces'
 import rdf from 'rdf-ext';
 import { toCURIE, toIRI } from 'shacl-tulip';
 
@@ -111,9 +111,21 @@ export function getPrefLabel(node, graphDataset, allPrefixes, from) {
   // console.log("Inside getPrefLabel")
   // console.log(allPrefixes)
   var prefLabel = ""
-  // Get quads related to a subject, and then isolate those that are 'DLTHINGS.annotations'
+  // Get quads related to a subject
   node.value = toIRI(node.value, allPrefixes)
   var relatedQuads = graphDataset.getSubjectTriples(node)
+  
+  // Isolate first quad with predicate 'skos:prefLabel'
+  var prefLabelQuad = relatedQuads.find((q) => {
+      return q.predicate.value == SKOS.prefLabel.value &&
+      q.object.termType === "Literal"
+  })
+
+  if (prefLabelQuad) {
+    return prefLabelQuad.object.value
+  }
+
+  // Isolate quads that are 'DLTHINGS.annotations'
   var annotationQuads = relatedQuads.filter((q) => {
       return q.predicate.value == DLTHINGS.annotations.value &&
       q.object.termType === "BlankNode"
@@ -167,6 +179,14 @@ export function adjustHexColor(hexColor, amount) {
   colorInt = Math.max(0, Math.min(0xFFFFFF, colorInt + amount));
   // Convert back to hex and ensure it's always 6 digits
   return `#${colorInt.toString(16).padStart(6, '0')}`;
+}
+
+export function getDisplayName(uri, configVarsMain, prefixes) {
+  if (configVarsMain.classNameDisplay == "curie") {
+    return toCURIE(uri, prefixes)
+  } else {
+    return toCURIE(uri, prefixes, "parts").property
+  }
 }
 
 export function getSuperClasses(class_uri, graph) {


### PR DESCRIPTION
Adds a new email editor component that matches sh:datatype == dltypes:EmailAddress

Adds several new configuration options for simpler UX and display

Three new configuration options are added:

1. 'class_name_display': this can have either of the values 'name' or 'curie';
   'name' is the default and will be displayed as e.g. 'Agent', whereas 'curie'
   will be displayed as 'dlprov:Agent'. This is used by the new 'getDisplayName'
   utility function that is now used across several components for uniform display.
2. 'hide_classes': this is an array of URIs for the classes that need to be hidden
   from the LHS pane that allows selecting a class to display its records. Including
   a new uri in the array will result in that users not seeing and not being able
   to select that class.
3. 'id_autogenerate' is an object with class URIs as keys and objects with config
   specs as values. For the case where the deployment should autogenerate the
   value of the 'pid' slot of a record of a particular class, the URI of that class
   should be included as a key in the 'id_autogenerate' object. The value is an object
   with possible keys 'id_autogenerate_prefix' and 'id_autogenerate_prepend'. The former
   should be the name of a known prefix in the deployment (e.g. 'dlthings') and the
   latter can be any string e.g. '/people'. For the given examples, the  'pid' field
   for a record of class  (for example) will then be populated as:
   '[https://concepts.datalad.org/s/things/v1/people/<randomUUID](https://concepts.datalad.org/s/things/v1/people/<randomUUID)>', where the randomUUID
   part is autogenerated with javascript's crypto.randomUUID().

In addition, support is added for expanded prefLabel usage. Specifically, the existing
utility function 'getPrefLabel' that previously only searched for Annotation class
records related to the record being displayed, has now been updated to also search
for direct skos:prefLabel properties of the record being displayed. If found, this
will receive preference above related Annotation classes and will be used for the
display name of the record.