### PR TITLE
More UI

### DIFF
--- a/src/components/NodeShapeViewer.vue
+++ b/src/components/NodeShapeViewer.vue
@@ -3,6 +3,8 @@
         <v-card-title class="text-h6">
             <v-icon>{{ getClassIcon(props.classIRI) }}</v-icon>&nbsp;
             <TextOrLinkViewer :textVal="record.title" :prefLabel="record.prefLabel"></TextOrLinkViewer>&nbsp;
+        </v-card-title>
+        <v-card-subtitle>
             <v-btn
                 icon="mdi-pencil"
                 variant="tonal"
@@ -10,8 +12,9 @@
                 class="rounded-lg"
                 @click="editInstanceItem(record)"
             ></v-btn>
-        </v-card-title>
-        <v-card-subtitle>{{ toCURIE(record.subtitle, allPrefixes) }}</v-card-subtitle>
+            &nbsp;
+            Type: <em>{{ toCURIE(record.subtitle, allPrefixes) }}</em>
+        </v-card-subtitle>
         <v-card-text v-if="!props.formOpen">
             <!-- literal and named nodes -->
             <span v-for="tt of ['Literal', 'NamedNode']">

--- a/src/components/NodeShapeViewer.vue
+++ b/src/components/NodeShapeViewer.vue
@@ -11,6 +11,7 @@
                 size="x-small"
                 class="rounded-lg"
                 @click="editInstanceItem(record)"
+                :disabled="props.formOpen"
             ></v-btn>
             &nbsp;
             Type: <em>{{ toCURIE(record.subtitle, allPrefixes) }}</em>


### PR DESCRIPTION
- Nodeshapeviewer: move edit button to the left of a record display card to make it always visible
- Nodeshapeviewer: hide edit button when a form is open
- Instancesselecteditor: Change list item display to preflabel if that predicate exists for a present record, and add custom filtering based on present preflabels