### PR TITLE
More UI

### DIFF
--- a/src/components/DateTimePickerEditor.vue
+++ b/src/components/DateTimePickerEditor.vue
@@ -67,7 +67,10 @@
     function valueCombiner(values) {
         if (values.picked_date) {
             try {
-                return values.picked_date.toISOString().split('T')[0]
+                var y = values.picked_date.getFullYear()
+                var m = ('0' + (parseInt(values.picked_date.getMonth())+1)).slice(-2)
+                var d = ('0' + values.picked_date.getDate()).slice(-2)
+                return `${y}-${m}-${d}`
             }
             catch (error) {
                 console.log(error)

--- a/src/components/FloatEditor.vue
+++ b/src/components/FloatEditor.vue
@@ -1,0 +1,85 @@
+<template>
+    <v-input
+        v-model="internalValue"
+        :rules="rules"
+        ref="fieldRef"
+        :id="inputId"
+        hide-details="auto"
+        style="margin-bottom: 1em;"
+    >
+        <v-text-field
+            v-model="subValues.float"
+            density="compact"
+            variant="outlined"
+            label="add floating point value"
+            hide-details="auto"
+        >
+        </v-text-field>
+    </v-input>
+</template>
+
+<script setup>
+    import { useRules } from '../composables/rules'
+    import { useRegisterRef } from '../composables/refregister';
+    import { useBaseInput } from '@/composables/base';
+
+    const props = defineProps({
+        modelValue: String,
+        property_shape: Object,
+        node_uid: String,
+        node_idx: String,
+        triple_uid: String,
+        triple_idx: Number
+    })
+    const { rules } = useRules(props.property_shape)
+    const inputId = `input-${Date.now()}`;
+    const { fieldRef } = useRegisterRef(inputId, props);
+    const emit = defineEmits(['update:modelValue']);
+    const { subValues, internalValue } = useBaseInput(
+        props,
+        emit,
+        valueParser,
+        valueCombiner
+    );
+
+    rules.value.push(
+      value => {
+        const regex = new RegExp('^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$');
+        if (!value) return true
+        if (regex.test(value)) return true
+        return 'Regular expression matching failed'
+        // TODO: this should be replaced by pattern-specific messaging, possibly using sh:message as source
+      }
+    )
+
+    function valueParser(value) {
+        // Parsing internalValue into ref values for separate subcomponent(s)
+        return {
+            float: value,
+        }
+    }
+
+    function valueCombiner(values) {
+        // Determine internalValue from subvalues/subcomponents
+        return values.float
+    }
+
+</script>
+
+<script>
+    import { SHACL, XSD } from '../modules/namespaces'
+    export const matchingLogic = (shape) => {
+        // sh:nodeKind exists
+        if ( shape.hasOwnProperty(SHACL.nodeKind.value) ) {
+            // sh:nodeKind == sh:Literal
+            if ( shape[SHACL.nodeKind.value] == SHACL.Literal.value ) {
+                // sh:datatype exists
+                if ( shape.hasOwnProperty(SHACL.datatype.value) ) {
+                    // sh:datatype == xsd:float
+                    return shape[SHACL.datatype.value] == XSD.float.value
+                }
+            }
+        }
+        return false
+    };
+</script>

--- a/src/components/PropertyShapeEditor.vue
+++ b/src/components/PropertyShapeEditor.vue
@@ -56,7 +56,7 @@
 
 <script setup>
     import { ref, onMounted, onBeforeMount, computed, inject, onBeforeUpdate, onBeforeUnmount, watch, toRaw} from 'vue'
-    import { SHACL } from '../modules/namespaces'
+    import { SHACL, DLCO} from '../modules/namespaces'
     import { useRules } from '../composables/rules'
     import { nameOrCURIE, addCodeTagsToText, isObject} from '../modules/utils';
     
@@ -68,6 +68,7 @@
         property_shape: Object,
         node_uid: String,
         node_idx: String,
+        top_level_prop: Boolean,
     })
 
     // ---- //
@@ -80,6 +81,7 @@
     const localPropertyShape = ref(props.property_shape)
     const localNodeUid = ref(props.node_uid)
     const localNodeIdx = ref(props.node_idx)
+    const localTopLevelProp = ref(props.top_level_prop)
     const editorMatchers = inject('editorMatchers');
     const defaultEditor = inject('defaultEditor');
     const formData = inject('formData');
@@ -159,15 +161,18 @@
         // and derived logic:
         // - show if the switch to "show_all_fields" is true
         // - show if the switch to "show_all_fields" is false, but the field is required
-        // - show if the switch to "show_all_fields" is false, but the field has a sh:name attribute in the shape
+        // - show if the switch to "show_all_fields" is false, but the field has a sv:recommended attribute in the shape
         //   (which means it was likely annotated and therefore likely important)
         if (show_all_fields.value) {
             return true
         } else {
+            if (localTopLevelProp.value) {
+                return true
+            }
             if (isRequired.value) {
                 return true
             }
-            if (localPropertyShape.value.hasOwnProperty(SHACL.name.value)) {
+            if (localPropertyShape.value.hasOwnProperty(DLCO.recommended.value) && localPropertyShape.value[DLCO.recommended.value] == "true") {
                 return true
             }
             return false


### PR DESCRIPTION
Introduce fixes and features for improved UI

- Adds new FloatEditor with basic regex check
- Fix off-by-one error of datetimepicker (TODO: allow only year, or year-month, to be selected)

Introduce semi-definitive rules for  class and property ordering and display in `NodeShapeViewer`:
- Group all properties by their originating class, and display these class groups in reverse hierarchical order
- Show the top-level class group by default
- Show all properties of the top-level group by default, ordered by the `sh:order` annotation of the property (relative to other properties in the group)
- Hide all other class groups and their properties by default, unless:
   - the property is required
   - the property is recommended (in LinkML, the slot has an annotation: `dlco:recommended: true`,
    with the prefix `dlco: https://concepts.datalad.org/`)
- For all non-top-level class groups, also order their displayed properties by the `sh:order` annotation of the property (relative to other properties in the group)

Notes:
- `sh:group` and `sh:PropertyGroup` annotations do not play any role in the above process
- it is important to re-annotate properties from inherited classes for when these properties' annotations are not relevant anymore in their new context.

