### PR TITLE
Requests to multiple services; grouping and ordering

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -15,15 +15,6 @@
     "use_default_data": false,
     "class_url": "dlschemas_owl.ttl",
     "use_default_classes": false,
-    "group_layout": "",
-    "defaultPropertyGroup": {
-        "key": "https://concepts.datalad.org/DefaultPropertyGroup",
-        "value": {
-            "http://www.w3.org/2000/01/rdf-schema#comment": "",
-            "http://www.w3.org/2000/01/rdf-schema#label": "Default Properties",
-            "http://www.w3.org/ns/shacl#order": 100
-        }
-    },
     "id_iri": "https://concepts.datalad.org/s/things/v1/pid",
     "id_autogenerate": {},
     "show_shapes_wo_id": false,

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -224,3 +224,17 @@ export function getSuperClass(class_uri, graph) {
   }
   return null
 }
+
+export function objectsEqual(obj1, obj2) {
+
+  if (Object.keys(obj1).length !== Object.keys(obj2).length) {
+    return false
+  }
+  
+  for (var key of Object.keys(obj1)) {
+    if (obj1[key] !== obj2[key]) {
+      return false
+    }
+  }
+  return true
+}

--- a/vite.config.app.mjs
+++ b/vite.config.app.mjs
@@ -46,6 +46,7 @@ export default defineConfig({
   build: {
     outDir: 'dist/app',
     emptyOutDir: true,
+    sourcemap: true,
     rollupOptions: {
       input: 'index.html',
     },


### PR DESCRIPTION
### Requests to multiple services

- closes https://github.com/psychoinformatics-de/shacl-vue/issues/103

This feature involves a configuration update where the 'service_base_url' option is changed from a single string to an array of objects of the form:
```
   {
      'url': 'https://metadata.inm7.de/simpleinput-unreleased/',
      'type': 'write'
   }
```
Other service-related configuration options remain unchanged. This is because the new feature allows requests to be sent to multiple service with the exact same API specifications and endpoint configurations, only the base url changes. In addition, `shacl-vue` is configured to send GET requests to base urls of all types, i.e. `read` and `write` (the latter implying the former), and to send POST requests only to `write`-type base urls. A `shacl-vue` deployment should be configured with one and only one `write` service, while it can be configured with any number of `read` services. The new feature is made backwards compatible with the previous manner of specifying the service url, via a single string. In this case the base url is assumed to be of type `write`.

To achieve the above, two composables `useData` (specifically the `fetchFromService` method) and `useForm` (specifically the `submitFormData` method) were updated. They handle the two possibilities of base urls in the format of a single string or an array. `fetchFromService` will now fetch from all urls specified via the s`ervice_base_url` config option, and `submitFormData` will only post to the single write-type base url configured via `service_base_url`. If none or more than 1 base urls of type `write` are found, errors are thrown and the submission is not continued.

### Grouping and ordering

- closes https://github.com/psychoinformatics-de/shacl-vue/issues/107 (see for full exploration)
-  closes https://github.com/psychoinformatics-de/shacl-vue/issues/105

This is the second or third attempt to really *fix* this approach. The previous method was found to be faulty when an exception showed a property appearing in a group that it shouldn't appear in. It was then updated to adhere to the approach defined by the following:

> A property should be divided into the class group that either made the latest change to it if it was inherited, or into the class that introduced the property.

This necessitated several updates to achieve correct grouping and ordering. Additionally, the updated method highlighted a non-ideal way in which LinkML assigns `sh:order` to property shapes of classes that are (also) derived from mixins.

Therefore, while deploying this update to `shacl-vue` instances will give these instances the updated ability to group and order properties correctly, grouping and ordering might still appear faulty if the underlying SHACL property shapes have faulty `sh:order` fields. For this to work, these instances should also receive updated SHACL exports that were generated by a patched version of LinkML that allows the exclusion of automatic `sh:order` assignment.

Lastly, since the previous `sh:PropertyGroup`-based approach to ordering is not used anymore, some remaining code relating to that feature was removed, including the `defaultPropertyGroup` option in the config. Also, the tab-layout was removed since it has never been used and has not been kept in sync with the rest of the `NodeShapeEditor` development.

### Sneaking in...

a change to fix https://github.com/psychoinformatics-de/shacl-vue/issues/101
