### PR TITLE
Fix the exclusion of properties from forms; Fix incorrect `no items` display

### DIFF
--- a/src/composables/useData.js
+++ b/src/composables/useData.js
@@ -89,6 +89,7 @@ export function useData(config) {
             const results = [];
             let allFailed = true;
             let anyFailed = false;
+            let allSkipped = true;
 
             for (const baseUrl of baseUrls) {
                 const getURL = `${baseUrl}${query_string}`;
@@ -110,6 +111,7 @@ export function useData(config) {
                     results.push({
                         url: getURL,
                         success: false,
+                        skipped: false,
                         message: result.message || "Failed to fetch RDF data."
                     });
                     anyFailed = true;
@@ -117,6 +119,7 @@ export function useData(config) {
                     results.push({
                         url: getURL,
                         success: true,
+                        skipped: false,
                     });
                     allFailed = false;
                 }
@@ -130,8 +133,15 @@ export function useData(config) {
                     url: results
                 };
             }
+            for (var r of results) {
+                if (!r.skipped) {
+                    allSkipped = false
+                    break;
+                }
+            }
             return {
                 success: true,
+                skipped: allSkipped,
                 url: results
             };
         } catch (error) {


### PR DESCRIPTION
### Regression fix: 'no items' displaying prematurely when new type selected

This issue existed before, and was reportedly fixed in https://github.com/psychoinformatics-de/shacl-vue/commit/b239149316b135d1024bc222e6cdffee2ebd6c48. However, the issue returned recently after several updates were made.

The latest approach is to watch the instanceItemsComp ref, which is a ref for the list of items that should update whenever new data is fetched from the backend service. It was first tried to set the classRecordsLoading value to false in the rdfDS.data.graphChanged watcher, but this still showed the 'no items' for a second before then displaying the actual instanceItemsComp list. So now a change was made to when the classRecordsLoading is set to false. It is done in the instanceItemsComp watcher, but importantly not on any change, since this ref changes each time a new data type is selected too. So  flag is put in place to ignore the first trigger of the watcher and to run on the second.

However, it was soon after found that the watcher does not always trigger twice. For data types that were selected previously and where the new selection will cause the fetchFromService call to return 'skipped' for all requests made, the classRecordsLoading also needed to be set to false, because otherwise the ref watcher would not trigger and the loader would display infinitely. To be able to know that all requests were skipped, the fetchFromService return values had to be updated in the useData composable.

Overall, this is a house of cards. Let's see when the next regression happens. For now I will leave it at this though.

### Correct handling of properties that should be excluded

The previous update to the grouping/ordering of properties in NodeShapeEditor caused some properties to slip through where they should actually not be rendered. Specifically 'rdf:type'. This commit changes how such properties are excluded, basically doing this upfront before the complex magical process of grouping and ordering commences.

- closes https://github.com/psychoinformatics-de/shacl-vue/issues/129
