### PR TITLE
Fix early display of 'no items'... again

### DIFF
--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -427,10 +427,19 @@
             classRecordsLoading.value = true
             // First fetch rdf data from configured service
             var result = await fetchFromService('get-records', IRI, allPrefixes)
-            if (!result.success) {
+            console.log("fetchFromService results status:")
+            console.log(result.status)
+            // If there was an actual error during the try statement
+            // before making the requests, relay error and deactivate loader
+            if (result.status === null) {
                 console.error(result.error)
+                classRecordsLoading.value = false
             }
-            if (result.success && result.skipped) {
+            // If any of the results were successful, don't set classRecordsLoading to false
+            // because it will be set during the watch event for instanceItemsComp
+            if (result.status.length && result.status.indexOf("success") >= 0 ) {
+                // do nothing   
+            } else {
                 classRecordsLoading.value = false
             }
         }

--- a/src/composables/useData.js
+++ b/src/composables/useData.js
@@ -90,6 +90,7 @@ export function useData(config) {
             let allFailed = true;
             let anyFailed = false;
             let allSkipped = true;
+            const results_status = []
 
             for (const baseUrl of baseUrls) {
                 const getURL = `${baseUrl}${query_string}`;
@@ -101,6 +102,7 @@ export function useData(config) {
                         skipped: true,
                         url: getURL
                     });
+                    results_status.push("skipped")
                     continue;
                 }
 
@@ -114,6 +116,7 @@ export function useData(config) {
                         skipped: false,
                         message: result.message || "Failed to fetch RDF data."
                     });
+                    results_status.push("failed")
                     anyFailed = true;
                 } else {
                     results.push({
@@ -122,13 +125,17 @@ export function useData(config) {
                         skipped: false,
                     });
                     allFailed = false;
+                    results_status.push("success")
                 }
             }
+            // Now we have an array of results
+            // Process all
             if (anyFailed) {
                 var error = new Error("One or more RDF data fetch attempts failed.");
                 return {
                     success: false,
                     message: error.message,
+                    status: Array.from(new Set(results_status)),
                     error: error,
                     url: results
                 };
@@ -142,12 +149,14 @@ export function useData(config) {
             return {
                 success: true,
                 skipped: allSkipped,
+                status: Array.from(new Set(results_status)),
                 url: results
             };
         } catch (error) {
             return {
                 success: false,
                 message: error.message,
+                status: null,
                 error: error,
                 url: null
             };


### PR DESCRIPTION
The problem of the eternal loader happened again. This time it was when the token was not entered for the backend service, and two base urls were configured. And it only happened when selecting a data type for the second time. So the requests were made, and one failed (no token) and one skipped (because of a successful previous fetch) but the existing logic did not account for this combination of results. So this update not returns an array of ['success', 'failed', 'skipped'] possible options from the fetchFromService routine. These are processed on return, and the classRecordsLoading ref is set to false only if there were no successful results (in the new 'status' field).