### PR TITLE
Updated : Fixes #110 and #118

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -36,8 +36,8 @@
                           dot
                           color="success"
                           overlap
-                          offset-x="3"
-                          offset-y="3"
+                          offset-x="12"
+                          offset-y="12"
                         >
                         <v-btn
                           icon="mdi-cloud-upload"

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -10,7 +10,7 @@
                 ></v-img>
             </a>
         </template>
-        <v-app-bar-title> 
+        <v-app-bar-title>
             <a @click="goToHome()" class="header-button"><code style="font-size: 1em;">{{ configVarsMain.appName }}</code></a>
         </v-app-bar-title>
 
@@ -19,7 +19,7 @@
             <span v-if="configVarsMain.useToken">
                 <v-tooltip text="Token" location="bottom">
                     <template v-slot:activator="{ props }">
-                        <v-btn 
+                        <v-btn
                         icon="mdi-key-variant"
                         @click="tokenFn()"
                         v-bind="props"
@@ -31,12 +31,30 @@
             <span v-if="configVarsMain.useService">
                 <v-tooltip text="Submit" location="bottom">
                     <template v-slot:activator="{ props }">
-                        <v-btn 
-                        icon="mdi-cloud-upload"
-                        @click="submitFn()"
-                        v-bind="props"
-                        :disabled="!canSubmit"
-                        ></v-btn>
+                        <v-badge
+                          v-if="pendingRecordsCount > 0 && !formOpen"
+                          dot
+                          color="success"
+                          overlap
+                          offset-x="3"
+                          offset-y="3"
+                        >
+                        <v-btn
+                          icon="mdi-cloud-upload"
+                          @click="submitFn()"
+                          v-bind="props"
+                          :disabled="!canSubmit"
+                        >
+                        </v-btn>
+                        </v-badge>
+                         <v-btn
+                            v-else
+                            icon="mdi-cloud-upload"
+                            @click="submitFn()"
+                            v-bind="props"
+                            :disabled="!canSubmit"
+                         >
+                         </v-btn>
                     </template>
                 </v-tooltip>
             </span>
@@ -44,7 +62,7 @@
             <span v-if="configVarsMain.documentationUrl">
                 <v-tooltip text="Documentation" location="bottom">
                     <template v-slot:activator="{ props }">
-                        <v-btn 
+                        <v-btn
                         icon="mdi-text-box"
                         :href="configVarsMain.documentationUrl"
                         target="_blank"
@@ -57,7 +75,7 @@
             <span v-if="configVarsMain.sourceCodeUrl">
                 <v-tooltip text="Source code" location="bottom">
                     <template v-slot:activator="{ props }">
-                        <v-btn 
+                        <v-btn
                         icon="mdi-code-not-equal-variant"
                         :href="configVarsMain.sourceCodeUrl"
                         target="_blank"
@@ -76,7 +94,7 @@
             <v-card-text>
                 A token is required to submit new/updated metadata records to the server,
                 or to view previously submitted metadata records. <br><br>
-                
+
                 <span v-if=configVarsMain.tokenInfo>
                     {{ configVarsMain.tokenInfo }}<span v-if=configVarsMain.tokenInfoUrl>: <a target="_blank" :href="configVarsMain.tokenInfoUrl">link</a></span>
                     <br><br>
@@ -107,7 +125,7 @@
     </v-dialog>
 </template>
 <script setup>
-    import { inject, onBeforeMount, ref} from 'vue'
+    import { inject, onBeforeMount, ref, computed} from 'vue'
     import { useToken } from '@/composables/tokens'
 
     const props = defineProps({
@@ -117,6 +135,8 @@
     const { token, setToken, clearToken } = useToken()
     const submitFn = inject('submitFn')
     const canSubmit = inject('canSubmit')
+    const formData = inject('formData')
+    const formOpen = inject('formOpen')
     const configVarsMain = inject('configVarsMain')
     const visible = ref(false)
     const tokenDialog = ref(false)
@@ -129,6 +149,10 @@
             return 'A token is required'
         },
     ]
+    // compute if records are pending to be submittedAdd commentMore actions
+    const pendingRecordsCount = computed(
+      () => Object.keys(formData.content).length
+    )
 
     onBeforeMount(()=>{
         if (token.value !== null && token.value !== "null") {
@@ -163,7 +187,7 @@
         const { valid } = await tokenForm.value.validate();
         if (!valid) {
             console.log("invalid")
-            return 
+            return
         }
         setToken(tokenval.value)
         tokenDialog.value = false

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -32,7 +32,7 @@
                 <v-tooltip text="Submit" location="bottom">
                     <template v-slot:activator="{ props }">
                         <v-badge
-                          v-if="pendingRecordsCount > 0 && !formOpen"
+                          v-if="nodesToSubmit.length > 0 && !formOpen"
                           dot
                           color="success"
                           overlap
@@ -135,7 +135,7 @@
     const { token, setToken, clearToken } = useToken()
     const submitFn = inject('submitFn')
     const canSubmit = inject('canSubmit')
-    const formData = inject('formData')
+    const nodesToSubmit = inject('nodesToSubmit')
     const formOpen = inject('formOpen')
     const configVarsMain = inject('configVarsMain')
     const visible = ref(false)
@@ -149,10 +149,6 @@
             return 'A token is required'
         },
     ]
-    // compute if records are pending to be submittedAdd commentMore actions
-    const pendingRecordsCount = computed(
-      () => Object.keys(formData.content).length
-    )
 
     onBeforeMount(()=>{
         if (token.value !== null && token.value !== "null") {

--- a/src/components/NodeShapeViewer.vue
+++ b/src/components/NodeShapeViewer.vue
@@ -10,33 +10,35 @@
         <v-card-subtitle>
             Type: <em>{{ toCURIE(record.subtitle, allPrefixes) }}</em>
             &nbsp;
-            <v-tooltip text="Edit record" location="bottom">
-                <template v-slot:activator="{ props }">
-                    <v-btn
-                        icon="mdi-pencil"
-                        variant="tonal"
-                        size="x-small"
-                        class="rounded-lg"
-                        @click="editInstanceItem(record)"
-                        :disabled="props.formOpen"
-                        v-bind="props"
-                    ></v-btn>
-                </template>
-            </v-tooltip>
-            &nbsp;
-            <v-tooltip text="View RDF" location="bottom">
-                <template v-slot:activator="{ props }">
-                    <v-btn
-                        icon="mdi-file-eye-outline"
-                        variant="tonal"
-                        size="x-small"
-                        class="rounded-lg"
-                        @click="viewRDF()"
-                        :disabled="props.formOpen"
-                        v-bind="props"
-                    ></v-btn>
-                </template>
-            </v-tooltip>
+            <span v-if="!props.formOpen">
+                <v-tooltip text="Edit record" location="bottom">
+                    <template v-slot:activator="{ props }">
+                        <v-btn
+                            icon="mdi-pencil"
+                            variant="tonal"
+                            size="x-small"
+                            class="rounded-lg"
+                            @click="editInstanceItem(record)"
+                            :disabled="props.formOpen"
+                            v-bind="props"
+                        ></v-btn>
+                    </template>
+                </v-tooltip>
+                &nbsp;
+                <v-tooltip text="View RDF" location="bottom">
+                    <template v-slot:activator="{ props }">
+                        <v-btn
+                            icon="mdi-file-eye-outline"
+                            variant="tonal"
+                            size="x-small"
+                            class="rounded-lg"
+                            @click="viewRDF()"
+                            :disabled="props.formOpen"
+                            v-bind="props"
+                        ></v-btn>
+                    </template>
+                </v-tooltip>
+            </span>
         </v-card-subtitle>
         <v-card-text v-if="!props.formOpen">
 

--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -38,7 +38,7 @@
                                                     <v-btn icon="mdi-chevron-left" density="compact" variant="outlined" @click="goBack()"></v-btn>
                                                     &nbsp;
                                                 </span>
-                                                
+
                                                 {{ getDisplayName(selectedIRI, configVarsMain, allPrefixes) }}
                                                 &nbsp;&nbsp; <v-btn icon="mdi-plus" size="x-small" variant="tonal" @click="addInstanceItem()" :disabled="openForms.length > 0"></v-btn>
                                             </h2>
@@ -105,7 +105,7 @@
                                         <span v-else style="margin-top: 1em; margin-left: 1em;">
                                             <em>Select a data type</em>
                                         </span>
-                                        
+
 
                                     </v-col>
                                     <v-col v-if="formOpen" cols="9">
@@ -163,7 +163,7 @@
 
 
 <script setup>
-    import { effect, ref, computed, provide, watch, reactive, onBeforeUpdate, nextTick, toRaw, defineAsyncComponent} from 'vue'
+    import { effect, ref, computed, provide, watch, reactive, onBeforeUpdate, nextTick, toRaw, defineAsyncComponent, onMounted, onBeforeUnmount} from 'vue'
     import { useConfig } from '@/composables/configuration';
     import { adjustHexColor, findObjectByKey, addCodeTagsToText, getSuperClasses, getDisplayName} from '../modules/utils';
     import {toCURIE, toIRI} from 'shacl-tulip'
@@ -197,7 +197,14 @@
     const { rdfDS, getRdfData, fetchFromService } = useData(config)
     const { classDS, getClassData } = useClasses(config)
     const { shapesDS, getSHACLschema } = useShapes(config)
-    const { formData, submitFormData } = useForm(config)
+    const { formData, submitFormData: _rawSubmitFormData } = useForm(config)
+    async function submitFormData(...args) {
+      const result = await _rawSubmitFormData(...args)
+      if (result?.success) {
+        Object.keys(formData.content).forEach(k => delete formData.content[k])
+      }
+      return result
+    }
     const { token, setToken, clearToken } = useToken()
     const ID_IRI = ref("")
     watch(configFetched, async (newValue) => {
@@ -240,6 +247,22 @@
     provide('formData', formData)
     provide('fetchFromService', fetchFromService)
     provide('submitFormData', submitFormData)
+    // ACCIDENTAL CLOSE PROTECTION , issue #110
+    // Warn if there are any pending entries in formData.content
+    function handleBeforeUnload(event) {
+      if (Object.keys(formData.content).length > 0) {
+        event.preventDefault()
+        event.returnValue = ""
+        return ""
+      }
+    }
+    onMounted(() => {
+      window.addEventListener("beforeunload", handleBeforeUnload)
+    })
+    onBeforeUnmount(() => {
+      window.removeEventListener("beforeunload", handleBeforeUnload)
+    })
+
     const superClasses = reactive({})
     provide('superClasses', superClasses)
     const searchText = ref("")
@@ -358,6 +381,7 @@
         graph: false,
     })
     provide('editMode', editMode)
+    provide('formOpen', formOpen)
     onBeforeUpdate( () => {
         console.log("onBeforeUpdate ShaclVue")
         editItemIdx.value = null
@@ -413,7 +437,7 @@
         }
         return shapeNames
     })
-    
+
 
     const formattedDescription = computed(() => {
         // For the class description, use a regular expression to replace text between backticks with <code> tags
@@ -431,7 +455,7 @@
         console.log(`Selecting type: ${IRI}`)
         console.log(filteredNodeShapeNames.value)
         console.log(shapesDS.data.nodeShapeNames)
-        
+
         console.log(selectedItem.value)
         newTypeSelected = true;
         var tempSearchText = searchText.value
@@ -454,7 +478,7 @@
             // If any of the results were successful, don't set classRecordsLoading to false
             // because it will be set during the watch event for instanceItemsComp
             if (result.status.length && result.status.indexOf("success") >= 0 ) {
-                // do nothing   
+                // do nothing
             } else {
                 classRecordsLoading.value = false
             }

--- a/src/components/SubmitComp.vue
+++ b/src/components/SubmitComp.vue
@@ -8,6 +8,21 @@
             >
                 <span v-if="!responseReceived">
                     <span v-if="tokenExists">
+
+                        You have edited and saved {{ nodesToSubmit.length }} record{{ nodesToSubmit.length == 1 ? '' : 's' }} for submission:
+                        
+                        <div style="margin-top: 0.7em; margin-bottom: 0.7em;">
+                            <em>
+                                <span v-for="r in nodesToSubmit">
+                                    &nbsp;&nbsp;
+                                    <v-icon>{{ getClassIcon(r.nodeshape_iri) }}</v-icon>&nbsp;
+                                    {{ getDisplayName(r.nodeshape_iri, configVarsMain, allPrefixes) }}:&nbsp;&nbsp;
+                                    {{ r.node_iri }}
+                                    <br>
+                                </span>
+                            </em>
+                        </div>
+
                         Are you sure you want to continue?
                     </span>
                     <span v-else>
@@ -70,6 +85,7 @@
 
 <script setup>
     import { ref, onBeforeMount, inject} from 'vue';
+    import { getDisplayName } from '@/modules/utils'
     import { useToken } from '@/composables/tokens'
 
     const props = defineProps({
@@ -87,8 +103,11 @@
     const tokenExists = ref(false)
     const shapesDS = inject('shapesDS')
     const rdfDS = inject('rdfDS')
+    const nodesToSubmit = inject('nodesToSubmit')
     const ID_IRI = inject('ID_IRI')
     const config = inject('config')
+    const configVarsMain = inject('configVarsMain')
+    const getClassIcon = inject('getClassIcon')
     const allPrefixes = inject('allPrefixes');
     const awaitingResponse = ref(false)
     const responseReceived = ref(false)

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -77,6 +77,10 @@ export function findObjectByKey(array, key, value) {
     return array.find(obj => obj[key] === value);
 }
 
+export function findObjectIndexByKey(array, key, value) {
+  return array.findIndex(obj => obj[key] === value);
+}
+
 export function replaceServiceIdentifier(id, arg_string, prefixes) {
   // id: The URI parameter to be formatter
   // arg_string: The formatting instruction "record?id={curie}&format=ttl";


### PR DESCRIPTION
PR for the same fix : https://github.com/psychoinformatics-de/shacl-vue/pull/140

- Fixes accidental close of windows and loss of data
- Green dot appears when there is something to be submiited. an indicator to the user


SH:  introduce tracking of saved, submitted, and to-be-submitted records:

This became necessary as a result of adding the feature to show a notification when there are records to be submitted. It became evident that using `formData` as a proxy for records to submit was ill-advised and that these should rather be tracked explicitly. The following specific changes were introduced:
- update `useForm` composable to return `savedNodes`, `submittedNodes`, and `nodesToSubmit`.
- upon any save of any form, the node shape and iri are added as an element (object) to `savedNodes`
- if the saved node is also a named node (which is determined by checking if it has a PID field) it is also added to `nodesToSubmit`, because blank nodes are not explicitly submitted by themselves, they are resolved within other nodes.
- upon successful submission, a submitted node is added to `submittedNodes`. In addition, it is removed from `nodesToSubmit`.
- the submission code in the composable is also updated to work from `nodesToSubmit` and not with `formData` anymore.
- Everywhere in the app, where a check is necessary to see if there are nodes to be submitted, it now uses the count of `nodesToSubmit`.
- The `SubmitComp` is updated to give a summary of the nodes to be submitted, before the user selects to go through with it.
