### PR TITLE
add page-mode to virtual scroller

### DIFF
--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -175,6 +175,7 @@
                                                         :items="
                                                             filteredInstanceItemsComp
                                                         "
+                                                        page-mode
                                                         :min-item-size="50"
                                                         key-field="title"
                                                         class="virtual-scroller"


### PR DESCRIPTION
This fixes the issue of the scroller trying to render too many items on top of each other, because a component height was not specified. See: https://github.com/Akryum/vue-virtual-scroller/issues/78