### PR TITLE
Pagination support

### DIFF
--- a/src/classes/ReactiveRdfDataset.js
+++ b/src/classes/ReactiveRdfDataset.js
@@ -1,6 +1,6 @@
 import { reactive, ref } from 'vue';
 import { RdfDataset } from 'shacl-tulip';
-import { Store } from 'n3';
+import { Store, Parser } from 'n3';
 
 export class ReactiveRdfDataset extends RdfDataset {
     constructor(data = reactive({})) {
@@ -69,5 +69,21 @@ export class ReactiveRdfDataset extends RdfDataset {
         // Toggle the dummy property to trigger reactivity
         this.data.graphChanged++;
         this.data.graph._dummy = !this.data.graph._dummy;
+    }
+
+    parseTTL(ttlString) {
+        const parser = new Parser();
+        parser.parse(ttlString, {
+            // onQuad (required) accepts a listener of type (quad: RDF.Quad) => void
+            onQuad: (err, quad) => {
+                if (quad) this.onDataFn(quad)
+            },
+            // onPrefix (optional) accepts a listener of type (prefix: string, iri: NamedNode) => void
+            onPrefix: (prefix, iri) => {
+                if (prefix && iri) this.onPrefixFn(prefix, iri)
+            },
+            // onComment (optional) accepts a listener of type (comment: string) => void
+            // onComment: (comment) => { console.log('#', comment); },
+        });
     }
 }

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -78,7 +78,7 @@ export function findObjectIndexByKey(array, key, value) {
 }
 
 export function replaceServiceIdentifier(id, arg_string, prefixes) {
-    // id: The URI parameter to be formatter
+    // id: The URI parameter to be formatted
     // arg_string: The formatting instruction "record?id={curie}&format=ttl";
 
     // First extract the part inside the curly brackets


### PR DESCRIPTION
### Adds `parseTTL` method to `ReactiveRdfDataset`
This is in preparation for handling backend pagination requests. The new pagination endpoint will return a json object with an `items` array containing TTL strings. The new function will parse a single TTL string and add prefixes and quads to the `RdfDataset`. This is opposed to the previous way in which an endpoint response was hanled, where the response was a TTL string, and the `shacl-tulip` functionality for fetching and directly processing the endpoint was used.

### Introduce handling of backend pagination endpoint requests
This was introduced in the backend because we started dealing with thousands of records returned for a single request, which caused bad UX in the frontend

This required several updates:

- a new `service_endpoints` key configuration: `get-paginated-records`
- using the new service endpoint for `fetchFromService` when a user selects a data type
- updating the `useData` composable substantially to handle paginated requests:
  - a new `getPaginatedRdfData` function to handle the request, instead of the existing `getRdfData` for non-pagination requests (which in turn calls `shacl-tulip` functionality, eventually)
  - keeping track of the returned metadata, specifically the amount of pages and last fetched page, for all data types (class IRIs) and for all service base URLs; this reactive variable to keep track of all pagination requests is also exposed to `ShaclVue`, so that that component can determine when requests should be made or not; 
  - using the tracked metadata to calculate which page to fetch next for a given class IRI and service base URL, or if the last page has already been fetched
  - a new utility function to determine of a given class IRI as unfetched pages for any of the service base URLs (this is used by `ShaclVue` component)
- updating the `ShaclVue` component with the `DynamicScroller` to implement pagination. The approach was to detect when the last item of the scroller is in view, and then triggering `fetchFromService` for the pagination `service_endpoint`, which in turn will determine if the next page should be fetced or not. The fetching process uses another skeleton loader (or infinite progress loader) to indicate that a new page is being fetched. When new page results return, the complete set of items to display in the scroller is recalculated. A floating button was introduced to scroll to the top, specifically for lists with many items.

Deployments wanting to use this functionality should add this to their config:

```
"service_endpoints":  {
    "post-record": "record/{name}?format=ttl",
    "get-record": "record?pid={curie}&format=ttl",
    "get-records": "records/{name}?format=ttl",
    "get-paginated-records": "records/p/{name}?format=ttl&size=50&page={page_number}"
},
```