### PR TITLE
Expand docs to include additional configuration options

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from 'vitepress'
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   base: "/shacl-vue/docs/",
-  title: "shacl-vue (alpha)",
+  title: "shacl-vue",
   description: "Automatic generation of user interfaces from SHACL",
   head: [['link', { rel: 'icon', href: '/shacl-vue/docs/favicon.ico' }]],
   themeConfig: {

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -4,7 +4,12 @@ layout: doc
 
 # Application configuration
 
-The URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/public/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/public/config.json) includes the following:
+
+Any unique instance of `shacl-vue` can be tailored to its specific use case and users through a custom configuration. This includes required instance inputs, such as the URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration.
+
+Configuration is done via a `config.json` file, available at [`shacl-vue/public/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/public/config.json)
+
+Current configuration options include:
 
 ## General app settings
 
@@ -19,16 +24,16 @@ The URLs to the input sources covered in the [Application Inputs section](./app-
 
 - `app_name` is the name of the application displayed in the browser tab and UI
 - `page_title` is the title for the HTML page
-- `documentation_url` is the URL of the user documentation
-- `source_code_url` is the URL of the source code repository
+- `documentation_url` is the URL of the user documentation for the specific `shacl-vue` instance
+- `source_code_url` is the URL of the source code repository for the specific `shacl-vue` instance
 
 The HTML page title is set in [`shacl-vue/src/components/ShaclVue.vue`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/src/components/ShaclVue.vue) based on values in the configuration file (`config.json`). The app uses the following priority when setting the title:
 
-1. If `page_title` is defined, use it;
-2. If `app_name` is defined, use it;
-3. Else, fallback to "shacl-vue".
+1. IF `page_title` is defined, use it;
+2. ELSE IF `app_name` is defined, use it;
+3. ELSE, fallback to "shacl-vue".
 
-URLs should be unique and absolute online URIs.
+URLs should be unique and resolvable online URIs.
 
 ## Theming settings (`app_theme`)
 
@@ -41,9 +46,6 @@ URLs should be unique and absolute online URIs.
         "vistied_color": "",
         "panel_color": "",
         "logo": "",
-        "inm7_darkblue": "#002a76",
-        "inm7_blue": "#014386",
-        "inm7_red": "#eb3822"  
 }
 ```
 
@@ -51,9 +53,8 @@ URLs should be unique and absolute online URIs.
 - `hover_color` is the link hover color
 - `active_color` is the link active state color
 - `visited_color` (Optional) is the visited link color
-- `panel_color` is the background color of UI panels
+- `panel_color` is the background color of the main left-hand-side UI panel displaying all data types
 - `logo` is the path to the logo used in the HTML page header
-- `inm7_darkblue`, `inm7_blue`, and `inm7_red` (Optional) are institutional colors for consistency across [INM7](https://www.fz-juelich.de/en/inm/inm-7) apps
 
 All colors should be defined using hexadecimal color codes (#RRGGBB). The logo path should either be a unique and absolute online URI, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
 
@@ -62,12 +63,11 @@ All colors should be defined using hexadecimal color codes (#RRGGBB). The logo p
 ```json
 {
     "shapes_url": "",
-    "use_default_shapes": true,
+    "use_default_shapes": false,
     "data_url": "",
-    "use_default_data": true,
+    "use_default_data": false,
     "class_url": "",
-    "use_default_classes": true,
-    "group_layout": ""
+    "use_default_classes": false,
 }
 ```
 
@@ -75,11 +75,10 @@ All colors should be defined using hexadecimal color codes (#RRGGBB). The logo p
 - `data_url` is the URL to fetch the data graph from
 - `class_url` is the URL to fetch the class hierarchy from
 - `use_default_shapes`, `use_default_data`, and `use_default_classes` specify using default demo files as fallback config URLs, when `true`
-- `group_layout` provides an option to customize the layout of groups in a form. The options include `default`, which is the standard vertically ordered layout, and `tabs`, which displays groups of properties in horizontal tabs.
 
-All URLs should either be unique and absolute online URIs, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
+All application input source URLs should either be unique and absolute online URIs, or a path relative to `shacl-vue/public` in the case of a file local to the repository. These URLs should return documents in TTL format.
 
-The defaults for all config URLs are the demo files.
+The defaults for all input source URLs are the repository-local demo files.
 
 ## Identifier settings
 
@@ -99,10 +98,10 @@ The defaults for all config URLs are the demo files.
 }
 ```
 
-- `id_iri` is the base IRI for new instance identifiers
-- `id_autogenerate` is a dictionary mapping RDF classes to auto-generated identifier rules: <br> `id_autogenerate_prefix`, `id_autogenerate_prepend`
-- `id_resolves_externally` is an array of class URIs for which IDs resolve elsewhere
-- `prefixes` is a JSON mapping from prefix to URI used throughout shacl-vue and RDF resources to support external vocabularies and local naming conventions
+- `id_iri` is the URI of the property that indicates the persistent identifier of an entity. It is central to the functioning of `shacl-vue` because it allows for the mapping between structured records and the representation of those records as named nodes in RDF graphs. The value of this option is dependent on the SHACL schema driving the `shacl-vue` instance. It defaults to `https://concepts.datalad.org/s/things/v1/pid` since the demo input sources are created from the `https://concepts.datalad.org/s/things/v1/` schema that implements that persistent identifier definition.
+- `id_autogenerate` is a dictionary mapping class IRIs to auto-generated identifier rules, and allows the `shacl-vue` instance to auto-generate the value of the `id_iri`-property (i.e. the `PID`) of a manually created record of a particular class. The auto-generated value is determined from two more configuration options, `id_autogenerate_prefix` and `id_autogenerate_prepend`, and a random component. `id_autogenerate_prefix` should be the name of a known prefix in the deployment (which can also be customized via configuration, see `prefixes` below), for example `dlthings`, and `id_autogenerate_prepend` can be any string e.g. '/people'. The construction is then `<resolved-prefix><prepended-string><random-string>`, where the random string part is generated with JavaScripts `crypto.randomUUID()`. For the given example strings, the `pid` field for a new record created manually in a `shacl-vue` instance will be: `https://concepts.datalad.org/s/things/v1/people/<randomUUID>'`.
+- `id_resolves_externally` is an array of class URIs for which their PIDs resolve online. Records of this class will have additional UI that allows them to be navigated to both inside the application and externally online.
+- `prefixes` is a JSON mapping from prefix to URI for prefixes used throughout a `shacl-vue` instance. While most namespaces known to a `shacl-vue` instance are derived from its input sources (SHACL schema, RDF data, class hierarchy information), this option allows additional prefixes to be supplied in order to support referencing external vocabularies and use-case specific naming conventions
 
 ## UI behavior
 
@@ -118,15 +117,23 @@ The defaults for all config URLs are the demo files.
 }
 ```
 
-- `show_shapes_wo_id` shows shapes that have no explicit ID defined, when `true`
-- `show_all_fields` displays all properties, even if not in SHACL shapes, when `true`
-- `hide_classes` is a list of RDF class URIs to hide from the class selector
-- `class_name_display` specifies whether to use `name` or `rdfs:label` for displaying class names
-- `class_icons` is a mapping of RDF classes to [Material Design Icons](https://pictogrammers.com/library/mdi/)
+- `show_shapes_wo_id` shows data types (in the left-hand-side panel) for which the driving SHACL shapes do not have the `id_iri` property defined, when `true`
+- `show_all_fields` displays all properties in the form editor when a record is created/edited, when `true`. Properties in the form editor are displayed by default in order of reverse inheritance. For example, if the `Person` class is derived from the `Thing` class, the form editor for a `Person` would display the `Person`-properties in top, and the `Thing`-properties below that. Often, only the top-level properties are of immediate interest or importance to users and UX is improved by hiding other properties. The `show_all_fields` option, when `false`, would hide lower-level properties and display the top-level properties and required properties when a user opens the form editor to add/edit a record. In addition to the configuration option, the UI still allows the user to toggle between showing and hiding lower-level properties.
+- `hide_classes` is a list of class URIs to hide from the left-hand-side panel listing all data types (i.e. classes)
+- `class_name_display` specifies whether to use the CURIE format or just the latter part of the CURIE for displaying class names in the `shacl-vue` UI. Allowed options are: 'curie' (for the full CURIE, e.g. `prov:Agent`) and 'name' (for the CURIE suffix, e.g. `Agent`) which is the default.
+- `class_icons` is a mapping of class URIs to [Material Design Icons](https://pictogrammers.com/library/mdi/)
 
 By default, `class_icons` that are not defined will display as empty circles.
 
 ## Service API integration
+
+While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
+
+While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
+
+While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
+
+While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
 
 ```json
 {
@@ -148,13 +155,13 @@ By default, `class_icons` that are not defined will display as empty circles.
     }
 }
 ```
-- `use_service` enables back-end API interaction, when `true`
-- `use-token` requires an authentication token, when `true`
-- `token_info` is instructional text about obtaining a token
-- `token_info_url` is a URL with token request information
-- `service_base_url` is a list of URL(s) of the API backend (can be an object with `url` and `type=read` or `type=write`)
-- `service_endpoints` is a mapping to endpoint templates
-- `service_fetch_before` are keys indicating which endpoints need preloading
+- `use_service` enables back-end API integration with a deployed `dump-things-server`, when `true`. This option is used throughout `shacl-vue` to enable/disable related UI options (such as the `Submit` button) and for internal request-related functionality
+- `use-token` allows the use of an authentication token, when `true`. This enables UI components for the user to enter a token, and adds this token to any requests made to the integrated service.
+- `token_info` is instructional text about obtaining a token that will be displayed to a user in the application UI
+- `token_info_url` is a URL that can be added to the instructional text that will be displayed to a user in the application UI
+- `service_base_url` is a list of URLs (minimum 1) of the integrated service. The `url` property's value should be the actual base URL, and the `type` property's value can be either `read` or `write`. This option allows a single `shacl-vue` instance to be integrated with multiple services, for example in curation use cases where user-submitted records should be pushed to a `write` backend, while records that the user should be able to see but not edit will be retrieved from a `read` backend.
+- `service_endpoints` is a mapping to endpoint templates, for the custom part of the endpoint URL that will be appended to the base URL before a request is made. These templates are typically useful for encoding query parameters. Template variables are included in curly brackets, and current options are `{name}` and `{curie}`, which follow the same definitions as given above for the `class_name_display` option. The `service_endpoint` options included in the example below are specific to integration with the `dump-things-service`.
+- `service_fetch_before` is a list of class URLs indicating from which endpoints records should be fetched upon application startup, i.e. before these classes are actually selected and viewed by the user.
 
 URLs should be unique and absolute online URIs.
 
@@ -172,7 +179,7 @@ An example usage of `service endpoints` and `service_fetch_before` is as follows
     },
     "service_fetch_before": {
         "get-record": [],
-        "get-records": []
+        "get-records": ["https://concepts.inm7.de/s/flat-base/unreleased/Person"]
     }
 }
 ```

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -4,7 +4,7 @@ layout: doc
 
 # Application configuration
 
-The URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/src/assets/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/src/assets/config.json) includes the following:
+The URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/public/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/public/config.json) includes the following:
 
 ```json
 {

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -4,7 +4,6 @@ layout: doc
 
 # Application configuration
 
-
 Any unique instance of `shacl-vue` can be tailored to its specific use case and users through a custom configuration. This includes required instance inputs, such as the URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration.
 
 Configuration is done via a `config.json` file, available at [`shacl-vue/public/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/public/config.json)
@@ -54,9 +53,9 @@ URLs should be unique and resolvable online URIs.
 - `active_color` is the link active state color
 - `visited_color` (Optional) is the visited link color
 - `panel_color` is the background color of the main left-hand-side UI panel displaying all data types
-- `logo` is the path to the logo used in the HTML page header
+- `logo` is the path to the logo used in the HTML page header.  The logo path should either be a unique and absolute online URI, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
 
-All colors should be defined using hexadecimal color codes (#RRGGBB). The logo path should either be a unique and absolute online URI, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
+All colors should be defined using hexadecimal color codes (#RRGGBB).
 
 ##  [Application inputs](./app-inputs) sources
 
@@ -121,17 +120,9 @@ The defaults for all input source URLs are the repository-local demo files.
 - `show_all_fields` displays all properties in the form editor when a record is created/edited, when `true`. Properties in the form editor are displayed by default in order of reverse inheritance. For example, if the `Person` class is derived from the `Thing` class, the form editor for a `Person` would display the `Person`-properties in top, and the `Thing`-properties below that. Often, only the top-level properties are of immediate interest or importance to users and UX is improved by hiding other properties. The `show_all_fields` option, when `false`, would hide lower-level properties and display the top-level properties and required properties when a user opens the form editor to add/edit a record. In addition to the configuration option, the UI still allows the user to toggle between showing and hiding lower-level properties.
 - `hide_classes` is a list of class URIs to hide from the left-hand-side panel listing all data types (i.e. classes)
 - `class_name_display` specifies whether to use the CURIE format or just the latter part of the CURIE for displaying class names in the `shacl-vue` UI. Allowed options are: 'curie' (for the full CURIE, e.g. `prov:Agent`) and 'name' (for the CURIE suffix, e.g. `Agent`) which is the default.
-- `class_icons` is a mapping of class URIs to [Material Design Icons](https://pictogrammers.com/library/mdi/)
-
-By default, `class_icons` that are not defined will display as empty circles.
+- `class_icons` is a mapping of class URIs to [Material Design Icons](https://pictogrammers.com/library/mdi/). By default, `class_icons` that are not defined will display as empty circles.
 
 ## Service API integration
-
-While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
-
-While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
-
-While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
 
 While source data is specified in the [Application Inputs section](./app-inputs) as one of the main inputs to a `shacl-vue` instance, this input does not have to come from a single TTL-document via the `data_url` configuration option. In fact, it is likely beneficial to many `shacl-vue` instances to allow getting data from (and pushing data to) a separately and continuously maintained data source, using standard HTTP. An example of such a source is the [Dump Things Service](https://github.com/christian-monch/dump-things-server), which is supported by `shacl-vue` via the `use_service` and related configuration options.
 
@@ -155,6 +146,7 @@ While source data is specified in the [Application Inputs section](./app-inputs)
     }
 }
 ```
+
 - `use_service` enables back-end API integration with a deployed `dump-things-server`, when `true`. This option is used throughout `shacl-vue` to enable/disable related UI options (such as the `Submit` button) and for internal request-related functionality
 - `use-token` allows the use of an authentication token, when `true`. This enables UI components for the user to enter a token, and adds this token to any requests made to the integrated service.
 - `token_info` is instructional text about obtaining a token that will be displayed to a user in the application UI

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -4,7 +4,7 @@ layout: doc
 
 # Application configuration
 
-The URLs to the input sources covered in the [Application Inputs section](./app-inputs) can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/src/assets/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/src/assets/config.json) includes the following:
+The URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/src/assets/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/src/assets/config.json) includes the following:
 
 ```json
 {

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -6,11 +6,67 @@ layout: doc
 
 The URLs to the input sources covered in the [Application Inputs section](./app-inputs), as well as various settings for theming, identifiers, UI behavior, and service API integration can all be configured easily in order to customize a `shacl-vue` instance. The current configuration, available at [`shacl-vue/public/config.json`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/public/config.json) includes the following:
 
+## General app settings
+
+```json
+{
+    "app_name": "",
+    "page_title": "",
+    "documentation_url": "",
+    "source_code_url": "",
+}
+```
+
+- `app_name` is the name of the application displayed in the browser tab and UI
+- `page_title` is the title for the HTML page
+- `documentation_url` is the URL of the user documentation
+- `source_code_url` is the URL of the source code repository
+
+The HTML page title is set in [`shacl-vue/src/components/ShaclVue.vue`](https://github.com/psychoinformatics-de/shacl-vue/blob/main/src/components/ShaclVue.vue) based on values in the configuration file (`config.json`). The app uses the following priority when setting the title:
+
+1. If `page_title` is defined, use it;
+2. If `app_name` is defined, use it;
+3. Else, fallback to "shacl-vue".
+
+URLs should be unique and absolute online URIs.
+
+## Theming settings (`app_theme`)
+
+```json
+{
+    "app_theme": {
+        "link_color": "",
+        "hover_color": "",
+        "active_color": "",
+        "vistied_color": "",
+        "panel_color": "",
+        "logo": "",
+        "inm7_darkblue": "#002a76",
+        "inm7_blue": "#014386",
+        "inm7_red": "#eb3822"  
+}
+```
+
+- `link_color` is the default link color
+- `hover_color` is the link hover color
+- `active_color` is the link active state color
+- `visited_color` (Optional) is the visited link color
+- `panel_color` is the background color of UI panels
+- `logo` is the path to the logo used in the HTML page header
+- `inm7_darkblue`, `inm7_blue`, and `inm7_red` (Optional) are institutional colors for consistency across [INM7](https://www.fz-juelich.de/en/inm/inm-7) apps
+
+All colors should be defined using hexadecimal color codes (#RRGGBB). The logo path should either be a unique and absolute online URI, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
+
+##  [Application inputs](./app-inputs) sources
+
 ```json
 {
     "shapes_url": "",
+    "use_default_shapes": true,
     "data_url": "",
+    "use_default_data": true,
     "class_url": "",
+    "use_default_classes": true,
     "group_layout": ""
 }
 ```
@@ -18,8 +74,105 @@ The URLs to the input sources covered in the [Application Inputs section](./app-
 - `shapes_url` is the URL to fetch the shapes graph from
 - `data_url` is the URL to fetch the data graph from
 - `class_url` is the URL to fetch the class hierarchy from
+- `use_default_shapes`, `use_default_data`, and `use_default_classes` specify using default demo files as fallback config URLs, when `true`
 - `group_layout` provides an option to customize the layout of groups in a form. The options include `default`, which is the standard vertically ordered layout, and `tabs`, which displays groups of properties in horizontal tabs.
 
-All URLs should either be unique and absolute online URIs, or a path relative to `shacl-vue/src` in the case of a file local to the repository.
+All URLs should either be unique and absolute online URIs, or a path relative to `shacl-vue/public` in the case of a file local to the repository.
 
 The defaults for all config URLs are the demo files.
+
+## Identifier settings
+
+```json
+{
+    "id_iri": "https://concepts.datalad.org/s/things/v1/pid",
+    "id_autogenerate": {
+        "": {
+            "id_autogenerate_prefix": "",
+            "id_autogenerate_prepend": ""
+        }
+    },
+    "id_resolves_externally": [],
+    "prefixes": {
+        "": ""
+    }
+}
+```
+
+- `id_iri` is the base IRI for new instance identifiers
+- `id_autogenerate` is a dictionary mapping RDF classes to auto-generated identifier rules: <br> `id_autogenerate_prefix`, `id_autogenerate_prepend`
+- `id_resolves_externally` is an array of class URIs for which IDs resolve elsewhere
+- `prefixes` is a JSON mapping from prefix to URI used throughout shacl-vue and RDF resources to support external vocabularies and local naming conventions
+
+## UI behavior
+
+```json
+{
+    "show_shapes_wo_id": true,
+    "show_all_fields": true,
+    "hide_classes": [],
+    "class_name_display": "",
+    "class_icons": {
+        "": ""
+    }
+}
+```
+
+- `show_shapes_wo_id` shows shapes that have no explicit ID defined, when `true`
+- `show_all_fields` displays all properties, even if not in SHACL shapes, when `true`
+- `hide_classes` is a list of RDF class URIs to hide from the class selector
+- `class_name_display` specifies whether to use `name` or `rdfs:label` for displaying class names
+- `class_icons` is a mapping of RDF classes to [Material Design Icons](https://pictogrammers.com/library/mdi/)
+
+By default, `class_icons` that are not defined will display as empty circles.
+
+## Service API integration
+
+```json
+{
+    "use_service": true,
+    "use_token": true,
+    "token_info": "",
+    "token_info_url": "",
+    "service_base_url": [
+        {
+            "url": "",
+            "type": ""
+        }
+    ],
+    "service_endpoints":  {
+        "": ""
+    },
+    "service_fetch_before": {
+        "": []
+    }
+}
+```
+- `use_service` enables back-end API interaction, when `true`
+- `use-token` requires an authentication token, when `true`
+- `token_info` is instructional text about obtaining a token
+- `token_info_url` is a URL with token request information
+- `service_base_url` is a list of URL(s) of the API backend (can be an object with `url` and `type=read` or `type=write`)
+- `service_endpoints` is a mapping to endpoint templates
+- `service_fetch_before` are keys indicating which endpoints need preloading
+
+URLs should be unique and absolute online URIs.
+
+### Example
+
+An example usage of `service endpoints` and `service_fetch_before` is as follows:
+
+```json
+{
+    "service_endpoints":  {
+        "post-record": "record/{name}?format=ttl",
+        "get-record": "record?pid={curie}&format=ttl",
+        "get-records": "records/{name}?format=ttl",
+        "get-paginated-records": "records/p/{name}?format=ttl&size=50&page={page_number}"
+    },
+    "service_fetch_before": {
+        "get-record": [],
+        "get-records": []
+    }
+}
+```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -22,25 +22,27 @@ Think of it as an automatic builder that you just have to feed with a model of y
 
 ## Installation
 
-`shacl-vue` is not yet available via any package manager, and will need to be installed from sources.
+`shacl-vue` can be installed from `npm` or from sources.
 
-First clone the repo locally:
-```
-git clone https://github.com/psychoinformatics-de/shacl-vue.git
-cd shacl-vue
-```
-
-Then create a local `NodeJS` virtual environment, for example with [miniconda](https://docs.anaconda.com/miniconda/):
+It is usually a good idea to start with a virtual environment. You can for example create a `NodeJS` environment with [miniconda](https://docs.anaconda.com/miniconda/):
 
 ```
 conda create -yn <my-env-name> nodejs
 conda activate <my-env-name>
 ```
 
-Then install the application:
+Then install `shacl-vue`:
 
 ```
-npm install
+npm install shacl-vue
+```
+
+For the latest development version, first clone the repo locally and then install `shacl-vue`:
+
+```
+git clone https://github.com/psychoinformatics-de/shacl-vue.git
+cd shacl-vue
+npm install .
 ```
 
 ### Local rendering

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: "shacl-vue (alpha)"
+  name: "shacl-vue"
   text: "Automatic generation of user interfaces from SHACL"
   image:
     src: /shacl_vue.svg


### PR DESCRIPTION
If merged, this PR closes https://github.com/psychoinformatics-de/shacl-vue/issues/113. It is a first draft at documenting the configuration options for shacl-vue instances, in addition to the app inputs config options that were previously documented.

A couple of notes:
- There were places pointing to `shacl-vue/src` for local repo files, that did not seem up-to-date, so I changed these to `shacl-vue/public` where necessary; please revert if this is incorrect
- `group-layout` was not implemented in the example instances from https://github.com/psychoinformatics-de/shacl-vue/issues/113, so I was not sure if it was still an option; I left it in for now

@jsheunis - Please review and make changes wherever it is needed to represent the true functionality; I would particularly appreciate if you could double-check the correctness of the "UI behavior" and "Service API integration" categories.

Thanks! 