### PR TITLE
Adds the `no_edit_classes` config option

### DIFF
--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -122,7 +122,7 @@ The defaults for all input source URLs are the repository-local demo files.
 - `hide_classes` is a list of class URIs to hide from the left-hand-side panel listing all data types (i.e. classes)
 - `no_edit_classes` prevents records of specific classes from being created or edited by users. It is a list of class URIs that will firstly be hidden from the left-hand-side panel, which duplicates the functionality of `hide_classes`. In addition:
    - users will not be able to create records of these classes via the `Add New Item` selection in an `InstancesSelectEditor`, i.e. the dropdown that allows users to select a specific record.
-   - users will not be able to use URL query parametes to navigate to the main view displaying records of these classes.
+   - users will not be able to use URL query parameters to navigate to the main view displaying records of these classes.
 - `class_name_display` specifies whether to use the CURIE format or just the latter part of the CURIE for displaying class names in the `shacl-vue` UI. Allowed options are: 'curie' (for the full CURIE, e.g. `prov:Agent`) and 'name' (for the CURIE suffix, e.g. `Agent`) which is the default.
 - `class_icons` is a mapping of class URIs to [Material Design Icons](https://pictogrammers.com/library/mdi/). By default, `class_icons` that are not defined will display as empty circles.
 

--- a/docs/app-configuration.md
+++ b/docs/app-configuration.md
@@ -109,6 +109,7 @@ The defaults for all input source URLs are the repository-local demo files.
     "show_shapes_wo_id": true,
     "show_all_fields": true,
     "hide_classes": [],
+    "no_edit_classes": [],
     "class_name_display": "",
     "class_icons": {
         "": ""
@@ -119,6 +120,9 @@ The defaults for all input source URLs are the repository-local demo files.
 - `show_shapes_wo_id` shows data types (in the left-hand-side panel) for which the driving SHACL shapes do not have the `id_iri` property defined, when `true`
 - `show_all_fields` displays all properties in the form editor when a record is created/edited, when `true`. Properties in the form editor are displayed by default in order of reverse inheritance. For example, if the `Person` class is derived from the `Thing` class, the form editor for a `Person` would display the `Person`-properties in top, and the `Thing`-properties below that. Often, only the top-level properties are of immediate interest or importance to users and UX is improved by hiding other properties. The `show_all_fields` option, when `false`, would hide lower-level properties and display the top-level properties and required properties when a user opens the form editor to add/edit a record. In addition to the configuration option, the UI still allows the user to toggle between showing and hiding lower-level properties.
 - `hide_classes` is a list of class URIs to hide from the left-hand-side panel listing all data types (i.e. classes)
+- `no_edit_classes` prevents records of specific classes from being created or edited by users. It is a list of class URIs that will firstly be hidden from the left-hand-side panel, which duplicates the functionality of `hide_classes`. In addition:
+   - users will not be able to create records of these classes via the `Add New Item` selection in an `InstancesSelectEditor`, i.e. the dropdown that allows users to select a specific record.
+   - users will not be able to use URL query parametes to navigate to the main view displaying records of these classes.
 - `class_name_display` specifies whether to use the CURIE format or just the latter part of the CURIE for displaying class names in the `shacl-vue` UI. Allowed options are: 'curie' (for the full CURIE, e.g. `prov:Agent`) and 'name' (for the CURIE suffix, e.g. `Agent`) which is the default.
 - `class_icons` is a mapping of class URIs to [Material Design Icons](https://pictogrammers.com/library/mdi/). By default, `class_icons` that are not defined will display as empty circles.
 

--- a/src/components/InstancesSelectEditor.vue
+++ b/src/components/InstancesSelectEditor.vue
@@ -47,31 +47,33 @@
                     ></v-skeleton-loader>
                 </span>
                 <span v-else>
-                    <v-list-item @click.stop :active="false">
-                        <v-list-item-title>
-                            <v-menu v-model="addItemMenu" location="end">
-                                <template v-slot:activator="{ props }">
-                                    <v-btn variant="tonal" v-bind="props"
-                                        >Add new item &nbsp;&nbsp;
-                                        <v-icon icon="item.icon"
-                                            >mdi-play</v-icon
-                                        ></v-btn
-                                    >
-                                </template>
+                    <span v-if="canEditClass">
+                        <v-list-item @click.stop :active="false">
+                            <v-list-item-title>
+                                <v-menu v-model="addItemMenu" location="end">
+                                    <template v-slot:activator="{ props }">
+                                        <v-btn variant="tonal" v-bind="props"
+                                            >Add new item &nbsp;&nbsp;
+                                            <v-icon icon="item.icon"
+                                                >mdi-play</v-icon
+                                            ></v-btn
+                                        >
+                                    </template>
 
-                                <v-list ref="addItemList">
-                                    <v-list-item
-                                        v-for="item in propClassList"
-                                        @click.stop="handleAddItemClick(item)"
-                                    >
-                                        <v-list-item-title>{{
-                                            item.title
-                                        }}</v-list-item-title>
-                                    </v-list-item>
-                                </v-list>
-                            </v-menu>
-                        </v-list-item-title>
-                    </v-list-item>
+                                    <v-list ref="addItemList">
+                                        <v-list-item
+                                            v-for="item in propClassList"
+                                            @click.stop="handleAddItemClick(item)"
+                                        >
+                                            <v-list-item-title>{{
+                                                item.title
+                                            }}</v-list-item-title>
+                                        </v-list-item>
+                                    </v-list>
+                                </v-menu>
+                            </v-list-item-title>
+                        </v-list-item>
+                    </span>
                     <span v-if="itemsToList.length">
                         <DynamicScroller
                             style="max-height: 200px; overflow-y: auto"
@@ -247,6 +249,8 @@ const propClassList = allclass_array.map((cl) => {
         value: cl,
     };
 });
+const canEditClass = ref(true)
+canEditClass.value = configVarsMain.noEditClasses.indexOf(propClass.value) < 0 ? true : false
 const { rules } = useRules(localPropertyShape.value);
 const inputId = `input-${Date.now()}`;
 const { fieldRef } = useRegisterRef(inputId, props);

--- a/src/components/ShaclVue.vue
+++ b/src/components/ShaclVue.vue
@@ -741,13 +741,16 @@ const idFilteredNodeShapeNames = computed(() => {
 const filteredNodeShapeNames = computed(() => {
     var names = idFilteredNodeShapeNames.value;
     console.log(names);
-    if (configVarsMain.hideClasses.length == 0) {
+    if (configVarsMain.hideClasses.length == 0 && configVarsMain.noEditClasses.length == 0) {
         return names;
     }
     var shapeNames = [];
     for (var n of names) {
         if (
             configVarsMain.hideClasses.indexOf(
+                shapesDS.data.nodeShapeNames[n]
+            ) < 0 &&
+            configVarsMain.noEditClasses.indexOf(
                 shapesDS.data.nodeShapeNames[n]
             ) < 0
         ) {
@@ -866,24 +869,34 @@ async function setViewFromQuery() {
     }
 
     if (instance_id) {
-        console.log('Queried ID FOUND');
+        console.log('ID in queryparams');
         queried_id.value = instance_id;
         console.log(queried_id.value);
     }
 
     if (nodeShape) {
-        console.log('Queried nodeshape FOUND');
+        console.log('Nodeshape in queryparams');
         // this could be a curie or iri
         // check if iri is in
         var nodeShapeIRI = toIRI(nodeShape, allPrefixes);
         if (shapesDS.data.nodeShapes[nodeShapeIRI]) {
-            await selectType(nodeShapeIRI);
-            if (edit) {
-                addInstanceItem();
-                updateURL(nodeShapeIRI, true);
+
+            if (configVarsMain.hideClasses.indexOf(nodeShapeIRI) < 0 &&
+                configVarsMain.noEditClasses.indexOf(nodeShapeIRI) < 0
+            ) {
+                await selectType(nodeShapeIRI);
+                if (edit) {
+                    addInstanceItem();
+                    updateURL(nodeShapeIRI, true);
+                }
+            }
+            else {
+                console.log('Queried nodeshape found in shacl schema, but present in hide_classes or no_edit_classes config options');
+                history.replaceState(null, '', window.location.pathname);
             }
         } else {
             console.log('Queried nodeshape not found in shacl schema');
+            history.replaceState(null, '', window.location.pathname);
         }
     } else {
         console.log('nodeshape not in query params');

--- a/src/composables/configuration.js
+++ b/src/composables/configuration.js
@@ -12,6 +12,7 @@ const mainVarsToLoad = {
     page_title: 'shacl-vue',
     show_shapes_wo_id: true,
     hide_classes: [],
+    no_edit_classes: [],
     id_autogenerate: {},
     prefixes: {},
     class_icons: {},


### PR DESCRIPTION
This prevents records of specific classes from being created or edited by users. It is a list of class URIs that will firstly be hidden from the left-hand-side panel. In addition:
- users will not be able to create records of these classes via the `Add New Item` selection in an `InstancesSelectEditor`, i.e. the dropdown that allows users to select a record.
- users will not be able to use URL query parametes to navigate to the main view displaying records of these classes.

Docs are updated accordingly.

Closes https://github.com/psychoinformatics-de/shacl-vue/issues/157