### PR TITLE
Update `DLTYPES` namespace

### DIFF
--- a/src/modules/namespaces.js
+++ b/src/modules/namespaces.js
@@ -14,7 +14,7 @@ export const DLTHING = namespace(
 );
 export const DLTHINGS = namespace('https://concepts.datalad.org/s/things/v1/');
 export const DLTYPES = namespace(
-    'https://concepts.datalad.org/s/types/unreleased/'
+    'https://concepts.datalad.org/s/types/v1/'
 );
 export const DLCO = namespace('https://concepts.datalad.org/');
 export const SKOS = namespace('http://www.w3.org/2004/02/skos/core#');


### PR DESCRIPTION
Version 1 of `dltypes` has been released, and `dlthings/v1` is using it. This means that it will be pulled in by pretty much all instances.

This breaks the email editor component, which is looking for its type in this schema.

This change fixes that by updating the version.

However, I think the type (actually types) that this editor should act on better become configurable. With more versions coming, it will become unsustainable to prescribe a particular schema.