### PR TITLE
Allow constrained and user-controlled display of amount of related records

### DIFF
--- a/src/components/BlankNodeViewer.vue
+++ b/src/components/BlankNodeViewer.vue
@@ -6,26 +6,28 @@
         no-gutters
     >
         <v-card-text style="padding: 0.5em; background-color: white">
-            <v-row justify="center" align="center">
-                <v-col cols="1"
-                    ><v-icon>{{
-                        getClassIcon(
-                            record.triples['NamedNode'][RDF.type.value][0].value
-                        )
-                    }}</v-icon></v-col
-                >
+            <v-row align="center" class="d-inline-flex">
+                <v-col style="flex: 0 0 30px; max-width: 30px;">
+                    <v-icon class="mr-1">
+                        {{
+                            getClassIcon(
+                                record.triples['NamedNode'][RDF.type.value][0].value
+                            )
+                        }}
+                    </v-icon>
+                </v-col>
                 <v-col>
                     <!-- literal and named nodes -->
                     <span v-for="tt of ['Literal', 'NamedNode']">
                         <span v-for="(v, k, index) in record.triples[tt]">
                             <span v-if="k != RDF.type.value">
-                                <em>{{
-                                    makeReadable(
-                                        toCURIE(k, allPrefixes, 'parts')
-                                            .property
-                                    )
-                                }}</em
-                                >:
+                                <em>
+                                    {{
+                                        makeReadable(
+                                            toCURIE(k, allPrefixes, 'parts').property
+                                        )
+                                    }}
+                                </em>:
                                 <span v-for="(el, i) in v">
                                     <span v-if="v.length > 1"
                                         ><br />&nbsp;-
@@ -42,12 +44,13 @@
                         </span>
                     </span>
                     <span v-for="(v, k, index) in record.triples['BlankNode']">
-                        <em>{{
-                            makeReadable(
-                                toCURIE(k, allPrefixes, 'parts').property
-                            )
-                        }}</em
-                        >:
+                        <em>
+                            {{
+                                makeReadable(
+                                    toCURIE(k, allPrefixes, 'parts').property
+                                )
+                            }}
+                        </em>:
                         <br />
                         <span v-for="(el, i) in v">
                             <div>

--- a/src/components/InstancesSelectEditor.vue
+++ b/src/components/InstancesSelectEditor.vue
@@ -429,8 +429,6 @@ onBeforeMount(async () => {
         scrollToSelectedItem();
         fetchingRecordLoader.value = false;
         fetchedItemCount.value = itemsToList.value.length;
-        console.log("fetchedItemCount.value")
-        console.log(fetchedItemCount.value)
     }
 });
 
@@ -599,8 +597,6 @@ const debouncedUpdate = debounce(() => {
     console.log('CHECK: graphdata instanceselecteditor');
     getItemsToList();
     fetchedItemCount.value = itemsToList.value.length;
-    console.log("fetchedItemCount.value")
-    console.log(fetchedItemCount.value)
     setSelectedValue();
 }, 500);
 watch(() => rdfDS.data.graphChanged, debouncedUpdate, { deep: true });

--- a/src/components/MoreOrLessRecordsViewer.vue
+++ b/src/components/MoreOrLessRecordsViewer.vue
@@ -1,0 +1,66 @@
+<template>
+    <span v-if="records.length > count">
+        <v-tooltip text="Show more..." location="top">
+            <template v-slot:activator="{ props }">
+                <v-btn
+                    v-bind:="props"
+                    no-gutters
+                    @click="increase()"
+                    density="compact"
+                    icon="mdi-plus"
+                    size="small"
+                    variant="tonal"
+                    rounded="sm"
+                ></v-btn>
+            </template>
+        </v-tooltip>
+    </span>
+    <span v-if="count > stepSize">
+        &nbsp;
+        <v-tooltip text="Show less..." location="top">
+            <template v-slot:activator="{ props }">
+                <v-btn
+                    v-bind:="props"
+                    no-gutters
+                    @click="decrease()"
+                    density="compact"
+                    icon="mdi-minus"
+                    size="small"
+                    variant="tonal"
+                    rounded="sm"
+                ></v-btn>
+            </template>
+        </v-tooltip>
+    </span>
+    <span v-if="records.length > stepSize">
+        &nbsp; <em>(showing {{ count }} of {{ records.length }})</em>
+    </span>
+</template>
+
+<script setup>
+const props = defineProps({
+    records: Array,
+    count: Number,
+    stepSize: Number,
+
+});
+
+const emit = defineEmits(['update:count']);
+
+function increase() {
+    const newTempCount = props.count + props.stepSize
+    const newCount = newTempCount > props.records.length ? props.records.length : newTempCount
+    emit('update:count', newCount);
+}
+
+function decrease() {
+    const newCount = props.count - props.stepSize < props.stepSize
+        ? props.stepSize
+        : props.count - props.stepSize;
+    emit('update:count', newCount);
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/src/components/TextOrLinkViewer.vue
+++ b/src/components/TextOrLinkViewer.vue
@@ -1,16 +1,25 @@
 <template>
     <span v-if="isLink">
-        <a :href="hrefVal" target="_blank">{{ contentVal }}</a>
+        <a :href="hrefVal" target="_blank" ref="el" class="text-ellipsis">{{ contentVal }}</a>
     </span>
-    <span v-else>{{ textVal }}</span>
+    <span v-else ref="el" class="text-ellipsis">{{ textVal }}</span>
+    <v-tooltip
+        v-if="isTruncated"
+        :text="contentVal || textVal"
+        :activator="el"
+        location="top start"
+        origin="start center"
+    />
 </template>
 
 <script setup>
-import { onBeforeMount, ref, inject } from 'vue';
+import { onBeforeMount, ref, inject, onMounted} from 'vue';
 import { toIRI } from 'shacl-tulip';
 const props = defineProps({
     textVal: String,
 });
+const isTruncated = ref(false)
+const el = ref(null);
 const allPrefixes = inject('allPrefixes');
 const isLink = ref(false);
 const hrefVal = ref('');
@@ -31,4 +40,21 @@ onBeforeMount(() => {
     }
     return;
 });
+onMounted( () => {
+    if (el.value) {
+        isTruncated.value = el.value.scrollWidth > el.value.clientWidth
+    }
+})
+
 </script>
+
+<style scoped>
+.text-ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: inline-block;
+    max-width: 400px;
+    vertical-align: bottom;
+}
+</style>

--- a/src/composables/configuration.js
+++ b/src/composables/configuration.js
@@ -28,8 +28,17 @@ const mainVarsToLoad = {
             yearEnd: 2077
         },
         InstancesSelectEditor: {
-            fetchingsRecordsText: "Fetching records..."
-        }
+            fetchingsRecordsText: "Fetching records...",
+        },
+        PropertyShapeEditor: {
+            recordNumberStepSize: 5,
+        },
+    },
+    viewer_config: {
+        NodeShapeViewer: {
+            recordNumberStepSize: 5,
+        },
+
     },
     display_name_autogenerate: {},
     display_name_autogenerate_placeholder: {


### PR DESCRIPTION
### Fix spacing/display of blank nodes in `NodeShapeViewer`

Closes #216 

### Allow constrained and user-controlled display of amount of related records

Closes: https://github.com/psychoinformatics-de/shacl-vue/issues/217

This pertains to both the `NodeShapeViewer`, which displays the literal nodes,
named nodes and blank nodes of a record being viewed, as well as the
`PropertyShapeEditor`, which renders all form fields of a record being edited.
It is possible that some related nodes of a record will have a list of multiple
values. For example, a distribution might have many parts and it is bad UX if
e.g. 500 (or a million) parts are rendered automatically for a given distribution
record, both in the record viewer and record editor components.

For this reason, a new feature was introduced whereby a default number of records
will be rendered automatically, and the user will then be able to decide whether
to show more records, or to show fewer, by using dedicated buttons.

This was achieved as follows:
- new config options were introduced, one per viewer/editor:
  - `editor_config[PropertyShapeEditor][recordNumberStepSize]` with a default of 5
  - `viewer_config[NodeShapeViewer][recordNumberStepSize]` with a default of 5
- the config options define how many records to show by default, and the user can
  increase this to the max corresponding to the number of records, and to the min
  corresponding to the default stepsize
- the new UX code was added explicitly to the `PropertyShapeEditor`, and then via the
  new `MoreOrLessRecordsViewer` to the `NodeShapeViewer`

For this new functionality to work seamlessly with the `PropertyShapeEditor`s
ability to add/remove triples for a given form property, the instantiation of any
given editor component (via the `component` tag) had to be updated. This was 
necessary because the previous state did not use the `key` of the component
correctly: it included the triple index where it should include the triple itself.
This is because the triple`s position in the data array might change, but the
triple node itself won't change. So using the index in the `key` actually lead to
unnecessary new components being instantiated every time the `key` changed; and
this also lead to bugs in triple display names which was how the issue was
noticed in the first place. After figuring this out and using the triple node
itself in the key, the bug was fixed. In addition, addition of a triple to the
data was updated to use splice in order to add the triple at the current index,
and not just to push to the last position in the array.

### Demo

https://github.com/user-attachments/assets/72c68921-df40-405a-9446-ea65ec75667c


