### PR TITLE
Trigger browser's password-save prompt on token entry

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -132,8 +132,9 @@
                 <v-form
                     ref="tokenForm"
                     validate-on="submit lazy"
-                    @submit.prevent
+                    @submit.prevent="save"
                 >
+                    <v-text-field name="username" autocomplete="username" style="display: none;"></v-text-field>
                     <v-text-field
                         v-model="tokenval"
                         :rules="rules"
@@ -141,22 +142,20 @@
                         :type="visible ? 'text' : 'password'"
                         density="compact"
                         placeholder="token"
+                        name="password"
+                        autocomplete="current-password"
                         prepend-inner-icon="mdi-lock-outline"
                         variant="outlined"
                         :error-messages="customError"
                         @click:append-inner="visible = !visible"
                     ></v-text-field>
+                    <div style="display: flex;">
+                        <v-btn @click="cancel()" style="margin-left: auto; margin-right: 0.5em;"><v-icon>mdi-close</v-icon> Cancel</v-btn>
+                        <v-btn @click="reset()" style="margin-right: 0.5em;"><v-icon>mdi-undo</v-icon> Reset</v-btn>
+                        <v-btn type="submit"><v-icon>mdi-check-circle-outline</v-icon> Save</v-btn>
+                    </div>
                 </v-form>
             </v-card-text>
-            <v-card-actions>
-                <v-btn @click="cancel()"
-                    ><v-icon>mdi-close</v-icon> Cancel</v-btn
-                >
-                <v-btn @click="reset()"><v-icon>mdi-undo</v-icon> Reset</v-btn>
-                <v-btn type="submit" @click="save()"
-                    ><v-icon>mdi-check-circle-outline</v-icon> Save</v-btn
-                >
-            </v-card-actions>
         </v-card>
     </v-dialog>
 </template>

--- a/src/components/SubmitComp.vue
+++ b/src/components/SubmitComp.vue
@@ -38,6 +38,7 @@
                     <span v-else>
                         Please add a valid token before submitting your changes.
                         <v-form ref="submitForm">
+                            <v-text-field name="username" autocomplete="username" style="display: none;"></v-text-field>
                             <v-text-field
                                 v-model="tokenval"
                                 :rules="rules"
@@ -45,6 +46,8 @@
                                     visible ? 'mdi-eye-off' : 'mdi-eye'
                                 "
                                 :type="visible ? 'text' : 'password'"
+                                name="password"
+                                autocomplete="current-password"
                                 density="compact"
                                 placeholder="token"
                                 prepend-inner-icon="mdi-lock-outline"


### PR DESCRIPTION
There are a few requirements for triggering a browser's password-save prompt correctly:
- there should be an actual html form that uses the '@submit' event
- there should be both a username and password input field, even if the former is hidden
- the 'autocomplete' tag should be used on both inputs
- the submit button should be 'type=submit' and should be placed inside the form

This commit applies the above to the token entry form